### PR TITLE
Claude/investigate plugin events s qw t5

### DIFF
--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -18,9 +18,9 @@ from rich.table import Table
 from .config import get_config, set_config, CONFIG_FILE
 from .dependencies import load_binary
 from .events import ArchiveResultEvent, BinaryInstalledEvent, ProcessCompletedEvent
-from .orchestrator import create_bus, download
+from .orchestrator import compute_phase_timeout, create_bus, download
 from .models import ArchiveResult, Process
-from .models import INSTALL_URL, discover_plugins, filter_plugins
+from .models import INSTALL_URL, Hook, Plugin, discover_plugins, filter_plugins
 
 console = Console()
 stderr_console = Console(stderr=True)
@@ -319,9 +319,19 @@ def dl(ctx, url: str, plugin_list: str | None, output_dir: str | None, timeout: 
         if selected
         else plugins
     )
-    total_hooks = sum(len(plugin.get_crawl_hooks()) + len(plugin.get_snapshot_hooks()) for plugin in selected_plugins.values())
+    crawl_hooks: list[tuple[Plugin, Hook]] = []
+    snapshot_hooks: list[tuple[Plugin, Hook]] = []
+    for plugin in selected_plugins.values():
+        for hook in plugin.get_crawl_hooks():
+            crawl_hooks.append((plugin, hook))
+        for hook in plugin.get_snapshot_hooks():
+            snapshot_hooks.append((plugin, hook))
+    total_timeout = (
+        compute_phase_timeout(crawl_hooks, config_overrides)
+        + compute_phase_timeout(snapshot_hooks, config_overrides)
+    )
     live_results: dict[str, VisibleRecord] = {}
-    bus = create_bus(num_hooks=total_hooks, timeout=timeout_seconds)
+    bus = create_bus(total_timeout=total_timeout)
 
     if interactive_tty:
         progress = Progress(
@@ -416,7 +426,8 @@ def _run_plugin_install(selected) -> int:
     binaries: dict[str, _BinaryRecord] = {}  # keyed by binary name
     hooks_ran: dict[tuple[str, str], Process] = {}  # all completed hooks
     failed_hooks: dict[tuple[str, str], Process] = {}  # hooks that failed
-    bus = create_bus(num_hooks=0, timeout=300)
+    crawl_hooks = [(plugin, hook) for plugin in selected.values() for hook in plugin.get_crawl_hooks()]
+    bus = create_bus(total_timeout=compute_phase_timeout(crawl_hooks))
 
     async def on_BinaryInstalledEvent(event: BinaryInstalledEvent) -> None:
         binaries[event.name] = _BinaryRecord(

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -330,6 +330,7 @@ def dl(ctx, url: str, plugin_list: str | None, output_dir: str | None, timeout: 
         compute_phase_timeout(crawl_hooks, config_overrides)
         + compute_phase_timeout(snapshot_hooks, config_overrides)
     )
+    total_hooks = len(crawl_hooks) + len(snapshot_hooks)
     live_results: dict[str, VisibleRecord] = {}
     bus = create_bus(total_timeout=total_timeout)
 
@@ -345,6 +346,10 @@ def dl(ctx, url: str, plugin_list: str | None, output_dir: str | None, timeout: 
         status_view = _LiveStatusView(live_results, progress, timeout_seconds)
         task_id = progress.add_task("[cyan]Running plugins...", total=total_hooks)
 
+        async def on_ProcessCompletedEvent(event: ProcessCompletedEvent) -> None:
+            """Advance progress for every completed hook (fg and bg)."""
+            progress.update(task_id, advance=1, description=f"[cyan]{escape(event.hook_name)}[/cyan]")
+
         async def on_ArchiveResultEvent(event: ArchiveResultEvent) -> None:
             ar = ArchiveResult(
                 snapshot_id=event.snapshot_id, plugin=event.plugin,
@@ -355,13 +360,8 @@ def dl(ctx, url: str, plugin_list: str | None, output_dir: str | None, timeout: 
                 error=event.error or None,
             )
             live_results[_record_key(ar)] = ar
-            # ArchiveResult from a binary install hook (not in total_hooks) —
-            # bump the total so the progress bar doesn't exceed 100%
-            task = progress.tasks[task_id]
-            if task.total is not None and task.completed >= task.total:
-                progress.update(task_id, total=task.total + 1)
-            progress.update(task_id, advance=1, description=f"[cyan]{escape(_record_hook_name(ar))}[/cyan]")
 
+        bus.on(ProcessCompletedEvent, on_ProcessCompletedEvent)
         bus.on(ArchiveResultEvent, on_ArchiveResultEvent)
 
         with Live(

--- a/abx_dl/events.py
+++ b/abx_dl/events.py
@@ -185,12 +185,15 @@ class ProcessKillEvent(BaseEvent):
     """Command: SIGTERM a background daemon hook via its PID file.
 
     Emitted by cleanup event handlers. ProcessService reads the PID file
-    and sends SIGTERM. Safe no-op if the hook already exited.
+    and sends SIGTERM, waits ``grace_period`` seconds for clean exit, then
+    escalates to SIGKILL. The grace period should be the plugin's timeout
+    (PLUGINNAME_TIMEOUT) so daemons get their configured time to flush.
     """
     plugin_name: str
     hook_name: str
     output_dir: str
-    event_timeout: float | None =10.0
+    grace_period: float = 15.0
+    event_timeout: float | None = 60.0
 
 
 class ProcessCompletedEvent(BaseEvent):

--- a/abx_dl/orchestrator.py
+++ b/abx_dl/orchestrator.py
@@ -86,7 +86,46 @@ from .models import ArchiveResult, Snapshot, write_jsonl
 from .models import Hook, Plugin, filter_plugins
 
 
-def create_bus(*, num_hooks: int, timeout: int = 60) -> EventBus:
+def get_plugin_timeout(plugin: Plugin, config: dict[str, Any] | None = None) -> int:
+    """Resolve a plugin's timeout from config overrides and schema defaults.
+
+    Checks (in priority order):
+    1. ``{PLUGIN_NAME}_TIMEOUT`` in *config*
+    2. ``TIMEOUT`` in *config*
+    3. ``{PLUGIN_NAME}_TIMEOUT`` default from the plugin's config_schema
+    4. Global default (60s)
+    """
+    name_upper = plugin.name.upper()
+    cfg = config or {}
+    # Check config overrides first
+    if f'{name_upper}_TIMEOUT' in cfg:
+        return int(cfg[f'{name_upper}_TIMEOUT'])
+    if 'TIMEOUT' in cfg:
+        return int(cfg['TIMEOUT'])
+    # Check plugin schema defaults
+    schema_def = plugin.config_schema.get(f'{name_upper}_TIMEOUT', {})
+    if isinstance(schema_def, dict) and 'default' in schema_def:
+        return int(schema_def['default'])
+    return 60
+
+
+def compute_phase_timeout(hooks: list[tuple[Plugin, Hook]], config: dict[str, Any] | None = None) -> float:
+    """Sum per-plugin timeouts across all hooks in a phase.
+
+    Each hook contributes its plugin's timeout (from ``get_plugin_timeout``).
+    This gives an accurate ceiling: slow plugins (e.g. YTDLP_TIMEOUT=120)
+    contribute more than fast ones (e.g. TITLE_TIMEOUT=10).
+
+    Returns at least 60.0 (minimum phase timeout).
+    """
+    total = sum(
+        get_plugin_timeout(plugin, config)
+        for plugin, _hook in hooks
+    )
+    return max(float(total), 60.0)
+
+
+def create_bus(*, total_timeout: float = 60.0) -> EventBus:
     """Create a configured EventBus for a download run.
 
     Callers should subscribe to events on the bus before passing it to
@@ -96,10 +135,9 @@ def create_bus(*, num_hooks: int, timeout: int = 60) -> EventBus:
         bus.on(ArchiveResultEvent, my_result_handler)
 
     Args:
-        num_hooks: Number of snapshot hooks (used to scale total timeout).
-        timeout: Per-hook timeout in seconds.
+        total_timeout: Total timeout for the entire run (sum of all phase
+            timeouts). Computed by ``compute_phase_timeout`` in download().
     """
-    total_timeout = max(float(num_hooks * timeout), float(timeout))
     return EventBus(
         name='AbxDl',
         # parallel event concurrency lets bg ProcessEvents (fire-and-forget
@@ -109,7 +147,7 @@ def create_bus(*, num_hooks: int, timeout: int = 60) -> EventBus:
         # entries instead of rejecting new events when the buffer fills
         max_history_size=1000,
         max_history_drop=True,
-        # Timeouts scale with the number of hooks × per-hook TIMEOUT.
+        # Total timeout covers both crawl and snapshot phases.
         # Individual hooks set their own timeouts via event_handler_timeout
         # on their ProcessEvent.
         event_timeout=total_timeout,
@@ -185,10 +223,14 @@ async def download(
     crawl_hooks.sort(key=lambda x: x[1].sort_key)
     snapshot_hooks.sort(key=lambda x: x[1].sort_key)
 
+    # Compute per-phase timeouts from plugin-specific settings
+    crawl_phase_timeout = compute_phase_timeout(crawl_hooks, config_overrides)
+    snapshot_phase_timeout = compute_phase_timeout(snapshot_hooks, config_overrides)
+    total_timeout = crawl_phase_timeout + snapshot_phase_timeout
+
     # Create bus if caller didn't provide one
-    timeout = int((config_overrides or {}).get('TIMEOUT', 60))
     if bus is None:
-        bus = create_bus(num_hooks=len(snapshot_hooks), timeout=timeout)
+        bus = create_bus(total_timeout=total_timeout)
 
     # Collect ArchiveResult records from the bus
     results: list[ArchiveResult] = []
@@ -224,10 +266,12 @@ async def download(
     CrawlService(
         bus, url=url, snapshot=snapshot, output_dir=output_dir,
         machine=machine_svc, hooks=crawl_hooks, crawl_only=crawl_only,
+        phase_timeout=crawl_phase_timeout,
     )
     SnapshotService(
         bus, url=url, snapshot=snapshot, output_dir=output_dir,
         machine=machine_svc, hooks=snapshot_hooks,
+        phase_timeout=snapshot_phase_timeout,
     )
 
     # --- Drive the lifecycle ---

--- a/abx_dl/orchestrator.py
+++ b/abx_dl/orchestrator.py
@@ -125,7 +125,7 @@ def compute_phase_timeout(hooks: list[tuple[Plugin, Hook]], config: dict[str, An
     return max(float(total), 60.0)
 
 
-def create_bus(*, total_timeout: float = 60.0) -> EventBus:
+def create_bus(*, total_timeout: float = 60.0, **kwargs) -> EventBus:
     """Create a configured EventBus for a download run.
 
     Callers should subscribe to events on the bus before passing it to
@@ -137,8 +137,10 @@ def create_bus(*, total_timeout: float = 60.0) -> EventBus:
     Args:
         total_timeout: Total timeout for the entire run (sum of all phase
             timeouts). Computed by ``compute_phase_timeout`` in download().
+        **kwargs: Extra keyword arguments passed through to the ``EventBus``
+            constructor (e.g. ``name``, ``middlewares``).
     """
-    return EventBus(
+    defaults = dict(
         name='AbxDl',
         # parallel event concurrency lets bg ProcessEvents (fire-and-forget
         # children) process concurrently with the parent event's serial handlers
@@ -154,6 +156,8 @@ def create_bus(*, total_timeout: float = 60.0) -> EventBus:
         event_slow_timeout=total_timeout * 0.8,
         event_handler_slow_timeout=60.0,
     )
+    defaults.update(kwargs)
+    return EventBus(**defaults)
 
 
 async def download(

--- a/abx_dl/services/base.py
+++ b/abx_dl/services/base.py
@@ -74,6 +74,7 @@ def make_hook_handler(
     snapshot: Snapshot,
     output_dir: Path,
     machine: MachineService,
+    phase_timeout: float = 300.0,
 ):
     """Create an async handler that emits a ProcessEvent for one hook.
 
@@ -83,6 +84,10 @@ def make_hook_handler(
 
     The env dict is built fresh each time from ``MachineService.shared_config``,
     so fg hooks pick up config updates (e.g. CHROME_BINARY path) from earlier hooks.
+
+    For background daemons, ``phase_timeout`` is used as the process timeout
+    ceiling instead of the per-hook timeout (daemons should survive until
+    cleanup kills them, but not outlive the entire phase).
     """
     async def handler(event: BaseEvent, _plugin=plugin, _hook=hook) -> None:
         env = machine.get_env_for_plugin(_plugin, run_output_dir=output_dir)
@@ -90,14 +95,18 @@ def make_hook_handler(
         plugin_output_dir = output_dir / _plugin.name
         plugin_output_dir.mkdir(parents=True, exist_ok=True)
 
+        # BG daemons use the full phase timeout as their ceiling (they should
+        # survive until cleanup, but not outlive the phase). FG hooks use
+        # the per-plugin timeout.
+        effective_timeout = int(phase_timeout) if _hook.is_background else timeout
         process_event = ProcessEvent(
             plugin_name=_plugin.name, hook_name=_hook.name,
             hook_path=str(_hook.path),
             hook_args=[f'--url={url}', f'--snapshot-id={snapshot.id}'],
             is_background=_hook.is_background,
             output_dir=str(plugin_output_dir), env=env,
-            snapshot_id=snapshot.id, timeout=timeout,
-            event_handler_timeout=timeout + 30.0,
+            snapshot_id=snapshot.id, timeout=effective_timeout,
+            event_handler_timeout=effective_timeout + 30.0,
         )
         if _hook.is_background:
             service.bus.emit(process_event)

--- a/abx_dl/services/crawl_service.py
+++ b/abx_dl/services/crawl_service.py
@@ -65,6 +65,7 @@ class CrawlService(BaseService):
         machine: MachineService,
         hooks: list[tuple[Plugin, Hook]],
         crawl_only: bool = False,
+        phase_timeout: float = 300.0,
     ):
         self.url = url
         self.snapshot = snapshot
@@ -72,6 +73,7 @@ class CrawlService(BaseService):
         self.machine = machine
         self.hooks = hooks
         self.crawl_only = crawl_only or (url == INSTALL_URL)
+        self.phase_timeout = phase_timeout
         super().__init__(bus)
 
     def _attach_handlers(self) -> None:
@@ -86,6 +88,7 @@ class CrawlService(BaseService):
                 self, plugin, hook,
                 url=self.url, snapshot=self.snapshot,
                 output_dir=self.output_dir, machine=self.machine,
+                phase_timeout=self.phase_timeout,
             )
             handler.__name__ = hook.name
             handler.__qualname__ = hook.name
@@ -104,7 +107,7 @@ class CrawlService(BaseService):
         url = self.url
         snapshot_id = self.snapshot.id
         output_dir = str(self.output_dir)
-        await self.bus.emit(CrawlSetupEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
+        await self.bus.emit(CrawlSetupEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir, event_timeout=self.phase_timeout))
         await self.bus.emit(CrawlStartEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
         await self.bus.emit(CrawlCleanupEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
         await self.bus.emit(CrawlCompletedEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))

--- a/abx_dl/services/crawl_service.py
+++ b/abx_dl/services/crawl_service.py
@@ -126,12 +126,20 @@ class CrawlService(BaseService):
         ))
 
     async def on_CrawlCleanupEvent(self, event: CrawlCleanupEvent) -> None:
-        """SIGTERM all background crawl daemons so they can flush and exit."""
+        """SIGTERM all background crawl daemons so they can flush and exit.
+
+        Each daemon gets its plugin's timeout (PLUGINNAME_TIMEOUT) as the
+        grace period before SIGKILL.
+        """
         for plugin, hook in self.hooks:
             if hook.is_background:
+                env = self.machine.get_env_for_plugin(plugin, run_output_dir=self.output_dir)
+                grace = float(env.get(f"{plugin.name.upper()}_TIMEOUT", env.get('TIMEOUT', '60')))
                 plugin_output_dir = self.output_dir / plugin.name
                 await self.bus.emit(ProcessKillEvent(
                     plugin_name=plugin.name,
                     hook_name=hook.name,
                     output_dir=str(plugin_output_dir),
+                    grace_period=grace,
+                    event_timeout=grace + 10.0,
                 ))

--- a/abx_dl/services/crawl_service.py
+++ b/abx_dl/services/crawl_service.py
@@ -109,7 +109,7 @@ class CrawlService(BaseService):
         output_dir = str(self.output_dir)
         await self.bus.emit(CrawlSetupEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir, event_timeout=self.phase_timeout))
         await self.bus.emit(CrawlStartEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
-        await self.bus.emit(CrawlCleanupEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
+        await self.bus.emit(CrawlCleanupEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir, event_timeout=self.phase_timeout))
         await self.bus.emit(CrawlCompletedEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
 
     async def on_CrawlStartEvent(self, event: CrawlStartEvent) -> None:

--- a/abx_dl/services/process_service.py
+++ b/abx_dl/services/process_service.py
@@ -246,13 +246,11 @@ class ProcessService(BaseService):
         """Gracefully shut down a background daemon via its PID file.
 
         Triggered by CrawlCleanupEvent/SnapshotCleanupEvent handlers. Validates the
-        PID file (mtime + command check), sends SIGTERM, waits up to 15s for
-        clean exit, then escalates to SIGKILL if the process is still alive.
-
-        The 15s grace period is important for Chrome, which needs time to flush
-        its user_data_dir (cookies, local storage, session state) on shutdown.
+        PID file (mtime + command check), sends SIGTERM, waits up to
+        ``grace_period`` for clean exit (the plugin's PLUGINNAME_TIMEOUT),
+        then escalates to SIGKILL if the process is still alive.
         """
         output_dir = Path(event.output_dir)
         pid_file = output_dir / f'{event.hook_name}.pid'
         cmd_file = output_dir / f'{event.hook_name}.sh'
-        await graceful_kill_by_pid_file(pid_file, cmd_file)
+        await graceful_kill_by_pid_file(pid_file, cmd_file, grace_period=event.grace_period)

--- a/abx_dl/services/process_service.py
+++ b/abx_dl/services/process_service.py
@@ -36,8 +36,9 @@ class ProcessService(BaseService):
         │   - Every line → ProcessStdoutEvent
         │     (each service parses and handles its own types)
         │
-        ├── Wait for process exit (with timeout)
-        │   - On timeout: SIGTERM → wait 2s → SIGKILL
+        ├── Wait for process exit
+        │   - FG hooks: per-plugin timeout, then SIGTERM → wait → SIGKILL
+        │   - BG daemons: no timeout (run until ProcessKillEvent)
         │
         └── Finalize:
             - Write Process record to index.jsonl
@@ -170,8 +171,12 @@ class ProcessService(BaseService):
                 await process.wait()
 
             timed_out = False
+            # Background daemons run until explicitly killed via
+            # ProcessKillEvent during cleanup — no timeout.
+            # Foreground hooks use the per-plugin timeout.
+            effective_timeout = None if event.is_background else (event.timeout or None)
             try:
-                await asyncio.wait_for(_stream_and_wait(), timeout=event.timeout or None)
+                await asyncio.wait_for(_stream_and_wait(), timeout=effective_timeout)
             except asyncio.TimeoutError:
                 timed_out = True
                 await graceful_kill_process(process)

--- a/abx_dl/services/process_service.py
+++ b/abx_dl/services/process_service.py
@@ -38,7 +38,8 @@ class ProcessService(BaseService):
         │
         ├── Wait for process exit
         │   - FG hooks: per-plugin timeout, then SIGTERM → wait → SIGKILL
-        │   - BG daemons: no timeout (run until ProcessKillEvent)
+        │   - BG daemons: full event timeout as ceiling (normally killed
+        │     earlier by ProcessKillEvent during cleanup)
         │
         └── Finalize:
             - Write Process record to index.jsonl
@@ -171,10 +172,11 @@ class ProcessService(BaseService):
                 await process.wait()
 
             timed_out = False
-            # Background daemons run until explicitly killed via
-            # ProcessKillEvent during cleanup — no timeout.
+            # Background daemons should survive until cleanup kills them
+            # via ProcessKillEvent, so they use the full event timeout
+            # (the overall run ceiling) instead of the per-hook timeout.
             # Foreground hooks use the per-plugin timeout.
-            effective_timeout = None if event.is_background else (event.timeout or None)
+            effective_timeout = (event.event_timeout or event.timeout or None) if event.is_background else (event.timeout or None)
             try:
                 await asyncio.wait_for(_stream_and_wait(), timeout=effective_timeout)
             except asyncio.TimeoutError:

--- a/abx_dl/services/process_service.py
+++ b/abx_dl/services/process_service.py
@@ -36,10 +36,11 @@ class ProcessService(BaseService):
         │   - Every line → ProcessStdoutEvent
         │     (each service parses and handles its own types)
         │
-        ├── Wait for process exit
-        │   - FG hooks: per-plugin timeout, then SIGTERM → wait → SIGKILL
-        │   - BG daemons: full event timeout as ceiling (normally killed
-        │     earlier by ProcessKillEvent during cleanup)
+        ├── Wait for process exit (with timeout)
+        │   - FG hooks: per-plugin timeout (PLUGINNAME_TIMEOUT)
+        │   - BG daemons: phase timeout ceiling (sum of all plugin timeouts
+        │     in the phase); normally killed earlier by ProcessKillEvent
+        │   - On timeout: SIGTERM → wait 15s → SIGKILL
         │
         └── Finalize:
             - Write Process record to index.jsonl
@@ -172,13 +173,8 @@ class ProcessService(BaseService):
                 await process.wait()
 
             timed_out = False
-            # Background daemons should survive until cleanup kills them
-            # via ProcessKillEvent, so they use the full event timeout
-            # (the overall run ceiling) instead of the per-hook timeout.
-            # Foreground hooks use the per-plugin timeout.
-            effective_timeout = (event.event_timeout or event.timeout or None) if event.is_background else (event.timeout or None)
             try:
-                await asyncio.wait_for(_stream_and_wait(), timeout=effective_timeout)
+                await asyncio.wait_for(_stream_and_wait(), timeout=event.timeout or None)
             except asyncio.TimeoutError:
                 timed_out = True
                 await graceful_kill_process(process)

--- a/abx_dl/services/snapshot_service.py
+++ b/abx_dl/services/snapshot_service.py
@@ -144,7 +144,7 @@ class SnapshotService(BaseService):
         url = self.url
         snapshot_id = self.snapshot.id
         output_dir = str(self.output_dir)
-        await self.bus.emit(SnapshotCleanupEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
+        await self.bus.emit(SnapshotCleanupEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir, event_timeout=self.phase_timeout))
         await self.bus.emit(SnapshotCompletedEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
 
     async def on_SnapshotCleanupEvent(self, event: SnapshotCleanupEvent) -> None:

--- a/abx_dl/services/snapshot_service.py
+++ b/abx_dl/services/snapshot_service.py
@@ -148,12 +148,20 @@ class SnapshotService(BaseService):
         await self.bus.emit(SnapshotCompletedEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir))
 
     async def on_SnapshotCleanupEvent(self, event: SnapshotCleanupEvent) -> None:
-        """SIGTERM all background snapshot daemons so they can flush and exit."""
+        """SIGTERM all background snapshot daemons so they can flush and exit.
+
+        Each daemon gets its plugin's timeout (PLUGINNAME_TIMEOUT) as the
+        grace period before SIGKILL.
+        """
         for plugin, hook in self.hooks:
             if hook.is_background:
+                env = self.machine.get_env_for_plugin(plugin, run_output_dir=self.output_dir)
+                grace = float(env.get(f"{plugin.name.upper()}_TIMEOUT", env.get('TIMEOUT', '60')))
                 plugin_output_dir = self.output_dir / plugin.name
                 await self.bus.emit(ProcessKillEvent(
                     plugin_name=plugin.name,
                     hook_name=hook.name,
                     output_dir=str(plugin_output_dir),
+                    grace_period=grace,
+                    event_timeout=grace + 10.0,
                 ))

--- a/abx_dl/services/snapshot_service.py
+++ b/abx_dl/services/snapshot_service.py
@@ -75,12 +75,14 @@ class SnapshotService(BaseService):
         output_dir: Path,
         machine: MachineService,
         hooks: list[tuple[Plugin, Hook]],
+        phase_timeout: float = 300.0,
     ):
         self.url = url
         self.snapshot = snapshot
         self.output_dir = output_dir
         self.machine = machine
         self.hooks = hooks
+        self.phase_timeout = phase_timeout
         super().__init__(bus)
 
     def _attach_handlers(self) -> None:
@@ -97,6 +99,7 @@ class SnapshotService(BaseService):
                 self, plugin, hook,
                 url=self.url, snapshot=self.snapshot,
                 output_dir=self.output_dir, machine=self.machine,
+                phase_timeout=self.phase_timeout,
             )
 
             async def guarded(event: SnapshotEvent, _inner=inner) -> None:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -591,7 +591,7 @@ def test_binary_installed_events(tmp_path: Path) -> None:
     """
     plugins_root = tmp_path / 'plugins'
     captured: list[tuple[str, str]] = []  # (name, abspath)
-    bus = create_bus(num_hooks=0, timeout=60)
+    bus = create_bus(total_timeout=60.0)
 
     async def on_installed(e: BinaryInstalledEvent) -> None:
         captured.append((e.name, e.abspath))
@@ -704,7 +704,7 @@ def test_archive_result_events_no_synthetic_when_inline_reported(tmp_path: Path)
     """
     plugins_root = tmp_path / 'plugins'
     ar_events: list[tuple[str, str]] = []  # (hook_name, status)
-    bus = create_bus(num_hooks=1, timeout=60)
+    bus = create_bus(total_timeout=60.0)
 
     async def on_ar(e: ArchiveResultEvent) -> None:
         ar_events.append((e.hook_name, e.status))

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -512,6 +512,74 @@ def test_cleanup_runs_after_all_hooks_not_interleaved(tmp_path: Path) -> None:
     )
 
 
+def test_bg_daemon_survives_past_timeout(tmp_path: Path) -> None:
+    """Background daemons must not be killed by the per-hook timeout.
+
+    Sets up a bg daemon with a 1-second timeout, plus a fg hook that sleeps
+    for 2 seconds (longer than the daemon's timeout). The daemon must still be
+    alive when the fg hook runs, proving the timeout doesn't apply to bg hooks.
+    """
+    plugins_root = tmp_path / 'plugins'
+    alive_marker = tmp_path / 'run' / 'bgdemo' / 'daemon_alive.marker'
+
+    # bg daemon with a very short timeout — writes a marker every 0.1s
+    _write(
+        plugins_root / 'bgdemo' / 'on_Snapshot__05_daemon.bg.py',
+        '\n'.join(
+            [
+                'import json',
+                'import signal',
+                'import sys',
+                'import time',
+                'from pathlib import Path',
+                '',
+                'def handle_sigterm(signum, frame):',
+                '    sys.exit(0)',
+                '',
+                'signal.signal(signal.SIGTERM, handle_sigterm)',
+                'print("[*] daemon ready", flush=True)',
+                'while True:',
+                f'    Path({str(alive_marker)!r}).write_text(str(time.time()))',
+                '    time.sleep(0.1)',
+            ]
+        )
+        + '\n',
+    )
+
+    # fg hook that sleeps 2s (longer than the 1s timeout), then checks daemon
+    _write(
+        plugins_root / 'checker' / 'on_Snapshot__10_check.py',
+        '\n'.join(
+            [
+                'import json',
+                'import time',
+                'from pathlib import Path',
+                'time.sleep(2)',
+                f'alive = Path({str(alive_marker)!r}).exists()',
+                # Read mtime to verify daemon wrote recently (within last 1s)
+                f'mtime = Path({str(alive_marker)!r}).stat().st_mtime if alive else 0',
+                'recent = (time.time() - mtime) < 1.0 if alive else False',
+                'print(json.dumps({"type": "ArchiveResult", "status": "succeeded",'
+                ' "output_str": f"alive={alive},recent={recent}"}))',
+            ]
+        )
+        + '\n',
+    )
+
+    plugins = discover_plugins(plugins_root)
+    # BGDEMO_TIMEOUT=1 sets a 1-second timeout for the bgdemo plugin only.
+    # The bg daemon must survive past this timeout (killed only at cleanup).
+    results = _run_download(
+        'https://example.com', plugins, tmp_path / 'run',
+        auto_install=True, config_overrides={'BGDEMO_TIMEOUT': '1'},
+    )
+
+    checker_result = next(r for r in results if r.plugin == 'checker')
+    assert checker_result.output_str == 'alive=True,recent=True', (
+        f'Background daemon was killed by timeout instead of surviving: {checker_result.output_str}'
+    )
+
+
 def test_binary_installed_events(tmp_path: Path) -> None:
     """Verify BinaryInstalledEvent fires for both pre-existing and provider-installed binaries.
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/abx-dl/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes early termination of background daemons and makes timeouts phase-aware. BG hooks run until cleanup with a per-phase ceiling; total run timeout sums per-plugin timeouts across phases; cleanup uses per-plugin grace. Also fixes CLI progress tracking and allows passing kwargs to `create_bus`.

- **Bug Fixes**
  - Prevent BG daemons from timing out early: set BG hook timeout to `phase_timeout`; set `event_timeout=phase_timeout` on `CrawlSetupEvent`/`CrawlCleanupEvent`/`SnapshotCleanupEvent`; daemon shutdown uses per-plugin `ProcessKillEvent.grace_period` (SIGTERM then SIGKILL).
  - Fix CLI progress and `total_hooks` NameError: compute hooks from crawl/snapshot lists; advance progress on `ProcessCompletedEvent` so every hook (fg and bg) counts.
  - Added `test_bg_daemon_survives_past_timeout`; updated tests to use `create_bus(total_timeout=...)`.

- **Refactors**
  - Added `get_plugin_timeout` and `compute_phase_timeout`; `create_bus` now takes `total_timeout` (and `**kwargs`); `cli`/`orchestrator` compute per-phase totals and pass `phase_timeout` to services and lifecycle events; `make_hook_handler` uses it for BG hooks.

<sup>Written for commit cbc75444ff2253354e1c1b877c41b21b6a13d28d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

