### PR TITLE
Add --output flag for filtering plugins by MIME type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -294,7 +294,7 @@ jobs:
 
       - name: Test all plugins
         run: |
-          uv run --no-sync --no-sources abx-dl dl 'https://example.com' --output=./test-output --timeout=120
+          uv run --no-sync --no-sources abx-dl dl 'https://example.com' --dir=./test-output --timeout=120
 
           echo "=== Output structure ==="
           find ./test-output -type f | head -50

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ One-off tuning is often easiest via env vars or CLI args:
 ```bash
 TIMEOUT=120 USER_AGENT='Mozilla/5.0 (abx-dl smoke test)' abx-dl 'https://example.com'
 CHROME_BINARY=/usr/bin/chromium --plugins=screenshot,pdf 'https://example.com'
-abx-dl --output=./runs/example --plugins=wget,title --timeout=90 'https://example.com'
+abx-dl --dir=./runs/example --plugins=wget,title --timeout=90 'https://example.com'
 ```
 
 <br/>
@@ -141,7 +141,7 @@ abx-dl --plugins=wget,title,screenshot,pdf 'https://example.com'
 abx-dl --no-install 'https://example.com'
 
 # Specify output directory:
-abx-dl --output=./downloads 'https://example.com'
+abx-dl --dir=./downloads 'https://example.com'
 
 # Set timeout:
 abx-dl --timeout=120 'https://example.com'
@@ -210,7 +210,7 @@ You can override the install location with `LIB_DIR=/path/to/lib abx-dl install 
 
 ### Output Structure
 
-By default, `abx-dl` writes results into the current working directory. Each run creates an `index.jsonl` manifest plus one subdirectory per plugin that produced output. If you want to keep runs isolated, `cd` into a scratch directory first or pass `--output=/path/to/run`.
+By default, `abx-dl` writes results into the current working directory. Each run creates an `index.jsonl` manifest plus one subdirectory per plugin that produced output. If you want to keep runs isolated, `cd` into a scratch directory first or pass `--dir=/path/to/run`.
 
 ```bash
 mkdir -p /tmp/abx-run && cd /tmp/abx-run

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -55,7 +55,7 @@ from .events import (
 from .limits import parse_filesize_to_bytes
 from .orchestrator import compute_install_phase_timeout, compute_phase_timeout, create_bus, download, get_install_plugins, install_plugins
 from .models import ArchiveResult, PluginEnv, Process, now_iso
-from .models import Hook, Plugin, discover_plugins, filter_plugins
+from .models import Hook, Plugin, discover_plugins, filter_plugins, plugins_matching_output
 from .output_files import OutputFile
 
 console = Console()
@@ -1133,6 +1133,7 @@ def cli(ctx):
 @cli.command()
 @click.argument("url")
 @click.option("--plugins", "-p", "plugin_list", help="Comma-separated list of plugins to use")
+@click.option("--output-types", "output_types", help="Comma-separated output MIME type prefixes to select plugins by (e.g. 'video/,text/html')")
 @click.option("--output", "-o", "output_dir", type=click.Path(), help="Output directory")
 @click.option("--timeout", "-t", type=int, help="Timeout in seconds")
 @click.option("--max-urls", type=int, default=0, help="Maximum number of URLs to snapshot for this crawl (0 = unlimited)")
@@ -1145,6 +1146,7 @@ def dl(
     ctx,
     url: str,
     plugin_list: str | None,
+    output_types: str | None,
     output_dir: str | None,
     timeout: int | None,
     dry_run: bool = False,
@@ -1164,16 +1166,26 @@ def dl(
 
         abx-dl --plugins=wget,ytdlp,git 'https://example.com'
 
+        abx-dl --output-types=video/,text/html 'https://example.com'
+
         abx-dl --no-install 'https://example.com'
 
         abx-dl dl 'https://example.com'
 
         abx-dl dl --plugins=wget,ytdlp,git 'https://example.com'
 
+        abx-dl dl --output-types=video/,text/html 'https://example.com'
+
         abx-dl dl --no-install 'https://example.com'
     """
     plugins = ctx.obj["plugins"]
     selected = [p.strip() for p in plugin_list.split(",")] if plugin_list else None
+    if output_types:
+        prefixes = [t.strip() for t in output_types.split(",") if t.strip()]
+        output_matched = plugins_matching_output(plugins, prefixes)
+        if not output_matched:
+            raise click.UsageError(f"No plugins found matching output types: {', '.join(prefixes)}")
+        selected = list(set(selected or []) | set(output_matched))
     out_path = Path(output_dir) if output_dir else Path.cwd()
     config_overrides: dict[str, object] = {"TIMEOUT": timeout} if timeout else {}
     if max_urls < 0:

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -1133,7 +1133,13 @@ def cli(ctx):
 @cli.command()
 @click.argument("url")
 @click.option("--plugins", "-p", "plugin_list", help="Comma-separated list of plugins to use")
-@click.option("--output", "-o", "output_types", multiple=True, help="Output MIME type prefixes to select plugins by (e.g. 'video,text/html'); repeatable")
+@click.option(
+    "--output",
+    "-o",
+    "output_types",
+    multiple=True,
+    help="Output MIME type prefixes to select plugins by (e.g. 'video,text/html'); repeatable",
+)
 @click.option("--dir", "-d", "output_dir", type=click.Path(), help="Output directory")
 @click.option("--timeout", "-t", type=int, help="Timeout in seconds")
 @click.option("--max-urls", type=int, default=0, help="Maximum number of URLs to snapshot for this crawl (0 = unlimited)")

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -1133,8 +1133,8 @@ def cli(ctx):
 @cli.command()
 @click.argument("url")
 @click.option("--plugins", "-p", "plugin_list", help="Comma-separated list of plugins to use")
-@click.option("--output", "output_types", help="Comma-separated output MIME type prefixes to select plugins by (e.g. 'video,text/html')")
-@click.option("--output-dir", "-o", "output_dir", type=click.Path(), help="Output directory")
+@click.option("--output", "-o", "output_types", multiple=True, help="Output MIME type prefixes to select plugins by (e.g. 'video,text/html'); repeatable")
+@click.option("--dir", "-d", "output_dir", type=click.Path(), help="Output directory")
 @click.option("--timeout", "-t", type=int, help="Timeout in seconds")
 @click.option("--max-urls", type=int, default=0, help="Maximum number of URLs to snapshot for this crawl (0 = unlimited)")
 @click.option("--max-size", default="0", help="Maximum total crawl size in bytes or units like 45mb / 1gb (0 = unlimited)")
@@ -1146,7 +1146,7 @@ def dl(
     ctx,
     url: str,
     plugin_list: str | None,
-    output_types: str | None,
+    output_types: tuple[str, ...],
     output_dir: str | None,
     timeout: int | None,
     dry_run: bool = False,
@@ -1168,6 +1168,8 @@ def dl(
 
         abx-dl --output=video,text/html 'https://example.com'
 
+        abx-dl -o image -o video -o text/ 'https://example.com'
+
         abx-dl --no-install 'https://example.com'
 
         abx-dl dl 'https://example.com'
@@ -1181,7 +1183,7 @@ def dl(
     plugins = ctx.obj["plugins"]
     selected = [p.strip() for p in plugin_list.split(",")] if plugin_list else None
     if output_types:
-        prefixes = [t.strip() for t in output_types.split(",") if t.strip()]
+        prefixes = [t.strip() for entry in output_types for t in entry.split(",") if t.strip()]
         output_matched = plugins_matching_output(plugins, prefixes)
         if not output_matched:
             raise click.UsageError(f"No plugins found matching output types: {', '.join(prefixes)}")

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -1133,8 +1133,8 @@ def cli(ctx):
 @cli.command()
 @click.argument("url")
 @click.option("--plugins", "-p", "plugin_list", help="Comma-separated list of plugins to use")
-@click.option("--output-types", "output_types", help="Comma-separated output MIME type prefixes to select plugins by (e.g. 'video/,text/html')")
-@click.option("--output", "-o", "output_dir", type=click.Path(), help="Output directory")
+@click.option("--output", "output_types", help="Comma-separated output MIME type prefixes to select plugins by (e.g. 'video,text/html')")
+@click.option("--output-dir", "-o", "output_dir", type=click.Path(), help="Output directory")
 @click.option("--timeout", "-t", type=int, help="Timeout in seconds")
 @click.option("--max-urls", type=int, default=0, help="Maximum number of URLs to snapshot for this crawl (0 = unlimited)")
 @click.option("--max-size", default="0", help="Maximum total crawl size in bytes or units like 45mb / 1gb (0 = unlimited)")
@@ -1166,7 +1166,7 @@ def dl(
 
         abx-dl --plugins=wget,ytdlp,git 'https://example.com'
 
-        abx-dl --output-types=video/,text/html 'https://example.com'
+        abx-dl --output=video,text/html 'https://example.com'
 
         abx-dl --no-install 'https://example.com'
 
@@ -1174,7 +1174,7 @@ def dl(
 
         abx-dl dl --plugins=wget,ytdlp,git 'https://example.com'
 
-        abx-dl dl --output-types=video/,text/html 'https://example.com'
+        abx-dl dl --output=video,text/html 'https://example.com'
 
         abx-dl dl --no-install 'https://example.com'
     """

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -463,7 +463,7 @@ def plugins_matching_output(plugins: dict[str, Plugin], output_prefixes: list[st
     declaring 'video/' matches a query for 'video/mp4'.
     """
     # normalize: 'video' -> 'video/', 'text/html' stays as-is
-    prefixes = [p if '/' in p else p + '/' for p in output_prefixes]
+    prefixes = [p if "/" in p else p + "/" for p in output_prefixes]
     matched: list[str] = []
     for name, plugin in plugins.items():
         for mimetype in plugin.config.output_mimetypes:

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -455,6 +455,23 @@ def discover_plugins(plugins_dir: Path = PLUGINS_DIR) -> dict[str, Plugin]:
     return plugins
 
 
+def plugins_matching_output(plugins: dict[str, Plugin], output_prefixes: list[str]) -> list[str]:
+    """Return plugin names whose output_mimetypes match any of the given prefixes.
+
+    A prefix like 'video/' matches 'video/mp4', 'video/webm', etc.
+    A prefix like 'text/html' matches exactly 'text/html'.
+    Matching is bidirectional: prefix 'video/' matches mimetype 'video/mp4',
+    and mimetype 'video/' (wildcard) matches prefix 'video/mp4'.
+    """
+    matched: list[str] = []
+    for name, plugin in plugins.items():
+        for mimetype in plugin.config.output_mimetypes:
+            if any(mimetype.startswith(p) or p.startswith(mimetype) for p in output_prefixes):
+                matched.append(name)
+                break
+    return matched
+
+
 def filter_plugins(plugins: dict[str, Plugin], names: list[str] | None, *, include_providers: bool = True) -> dict[str, Plugin]:
     """Filter plugins to only include specified names, plus transitive dependencies.
 

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -458,15 +458,16 @@ def discover_plugins(plugins_dir: Path = PLUGINS_DIR) -> dict[str, Plugin]:
 def plugins_matching_output(plugins: dict[str, Plugin], output_prefixes: list[str]) -> list[str]:
     """Return plugin names whose output_mimetypes match any of the given prefixes.
 
-    A prefix like 'video/' matches 'video/mp4', 'video/webm', etc.
-    A prefix like 'text/html' matches exactly 'text/html'.
-    Matching is bidirectional: prefix 'video/' matches mimetype 'video/mp4',
-    and mimetype 'video/' (wildcard) matches prefix 'video/mp4'.
+    Prefixes without a '/' get one appended so 'video' matches 'video/*'.
+    Matching is bidirectional: 'video/' matches 'video/mp4', and a plugin
+    declaring 'video/' matches a query for 'video/mp4'.
     """
+    # normalize: 'video' -> 'video/', 'text/html' stays as-is
+    prefixes = [p if '/' in p else p + '/' for p in output_prefixes]
     matched: list[str] = []
     for name, plugin in plugins.items():
         for mimetype in plugin.config.output_mimetypes:
-            if any(mimetype.startswith(p) or p.startswith(mimetype) for p in output_prefixes):
+            if any(mimetype.startswith(p) or p.startswith(mimetype) for p in prefixes):
                 matched.append(name)
                 break
     return matched

--- a/server/server.py
+++ b/server/server.py
@@ -166,7 +166,7 @@ def create_session(url: str, plugins: list[str], timeout: int = DEFAULT_TIMEOUT)
 
 def _run_download(sid: str, url: str, plugins: list[str], timeout: int) -> None:
     sdir = session_dir(sid)
-    cmd = ["abx-dl", "dl", "--output", str(sdir)]
+    cmd = ["abx-dl", "dl", "--dir", str(sdir)]
     if plugins:
         cmd += ["--plugins", ",".join(plugins)]
     cmd += ["--timeout", str(timeout)]

--- a/skills/abx-dl/SKILL.md
+++ b/skills/abx-dl/SKILL.md
@@ -66,14 +66,14 @@ abx-dl --plugins=title,wget,screenshot 'https://example.com'
 - Write into an explicit output directory:
 
 ```bash
-abx-dl --output=./runs/example 'https://example.com'
+abx-dl --dir=./runs/example 'https://example.com'
 ```
 
 ## Output Behavior
 
 - By default, output is written into the current working directory.
 - Expect an `index.jsonl` file plus plugin-specific subdirectories such as `./title/`, `./wget/`, `./screenshot/`, and `./pdf/`.
-- For clean automation, create a throwaway working directory first or always pass `--output=...`.
+- For clean automation, create a throwaway working directory first or always pass `--dir=...`.
 - `on_CrawlSetup__*` hooks do not emit stdout JSONL records.
 - `on_Snapshot__*` hooks emit `ArchiveResult` and may also emit `Snapshot` and `Tag`.
 
@@ -88,7 +88,7 @@ find . -maxdepth 2 -type f | sort
 ## Tuning Behavior
 
 - Useful CLI flags:
-  - `--plugins=title,wget,...`, `--output=DIR`, `--timeout=120`, `--no-install`
+  - `--plugins=title,wget,...`, `--output=video,text/html`, `--dir=DIR`, `--timeout=120`, `--no-install`
 
 - Useful env vars:
   - `TIMEOUT`, `USER_AGENT`, `CHECK_SSL_VALIDITY`
@@ -119,7 +119,7 @@ abx-dl config --set WGET_ENABLED=false
 
 ## Recommended Agent Workflow
 
-1. Run in a clean directory or pass `--output=...`.
+1. Run in a clean directory or pass `--dir=...`.
 2. Install the CLI with `uv run` or `uvx`.
 3. Run `abx-dl plugins` or `abx-dl install ...` if dependency state matters.
 4. Run `abx-dl '<url>'` with any needed `--plugins`, `--timeout`, or env vars.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -758,7 +758,7 @@ def test_readme_dl_command_downloads_example_dot_com_with_real_output(tmp_path: 
         tmp_path,
         "dl",
         "--plugins=wget",
-        f"--output={output_dir}",
+        f"--dir={output_dir}",
         "https://example.com",
     )
     assert result.returncode == 0


### PR DESCRIPTION
## Summary
This PR adds a new `--output` flag to filter plugins based on their output MIME types, and renames the output directory flag from `--output` to `--dir` for clarity.

## Key Changes

- **New `--output` flag**: Allows users to specify output MIME type prefixes (e.g., `--output=video,text/html`) to automatically select plugins that produce matching output types. The flag is repeatable for multiple values.
  - Implements flexible prefix matching: `video` matches `video/*`, and matching is bidirectional
  - Automatically combines selected plugins with any explicitly specified via `--plugins`
  - Raises a clear error if no plugins match the specified output types

- **Renamed `--output` to `--dir`**: The output directory option is now `--dir` (short form `-d`) to avoid confusion with the new `--output` flag for MIME type filtering

- **New `plugins_matching_output()` function**: Added to `models.py` to handle the logic of matching plugins against output MIME type prefixes with bidirectional matching support

- **Updated documentation and examples**: All references to `--output=<dir>` have been updated to `--dir=<dir>` in README, SKILL.md, test files, and workflow configurations

## Implementation Details

The `plugins_matching_output()` function normalizes MIME type prefixes (e.g., `video` → `video/`) and performs bidirectional matching to handle both user queries and plugin declarations flexibly. When `--output` is specified, matched plugins are merged with any explicitly selected plugins via `--plugins`.

https://claude.ai/code/session_018HEYPo5BTVjcjBp1cJdRFC
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/abx-dl/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `--output` flag to auto-select plugins by output MIME type prefixes, and renames the output directory flag to `--dir`/`-d` to avoid confusion.

- **New Features**
  - Filter plugins by output MIME types with `--output` (repeatable or CSV), e.g., `--output=video,text/html` or `-o image -o video`.
  - Flexible prefix matching: bare tokens normalize (`video` → `video/`), and matching is bidirectional (`video/` ↔ `video/mp4`).
  - Auto-selected plugins are unioned with `--plugins`; clear error if no matches.

- **Migration**
  - Replace `--output=DIR` with `--dir=DIR` (alias `-d`) in scripts and docs.

<sup>Written for commit 7c3c96bde70908d6122d830ebb0bf9a26f0da706. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

