### PR TITLE
Support file extensions in --output filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ abx-dl --plugins=wget,title,screenshot,pdf,readability,git 'https://example.com'
 
 Plugins are loaded from the installed [`abx-plugins`](https://pypi.org/project/abx-plugins/) package (or from `ABX_PLUGINS_DIR` if you override it) and execute in distinct phases:
 1. **Install phase** runner reads plugins `config.json`: `required_binaries` and emits `BinaryRequestEvent`s ➡️ which go to **BinaryRequest hooks** (`on_BinaryRequest__*`) that answer requests using apt/brew/env/etc.
-2. **CrawlSetup hooks** (`on_CrawlSetup__*`) launch/configure expensive crawl-scoped processes like chrome, ot trigger side effects. they emit no stdout JSONL records.
+2. **CrawlSetup hooks** (`on_CrawlSetup__*`) launch/configure expensive crawl-scoped processes like chrome, or trigger side effects. they emit no stdout JSONL records.
 4. **Snapshot hooks** (`on_Snapshot__*`) run per URL to extract content and emit only `ArchiveResult`, `Snapshot`, and `Tag` records
 
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,11 @@ uvx abx-dl@latest install
 # Default command - a bare URL archives with all enabled plugins:
 abx-dl 'https://example.com'
 
-# Limit work to a subset of plugins:
+# Select plugins by output type (mimetypes, categories, or file extensions):
+abx-dl --output=html,pdf,video/ 'https://example.com'
+abx-dl -o text -o image -o mp4 'https://example.com'
+
+# Limit work to a subset of plugins by name:
 abx-dl --plugins=wget,title,screenshot,pdf 'https://example.com'
 
 # Skip auto-installing missing dependencies (emit warnings instead):

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -1298,7 +1298,7 @@ def dl(
             download_task = loop.create_task(
                 download(
                     url,
-                    plugins,
+                    selected_plugins,
                     out_path,
                     selected,
                     config_overrides or None,

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -1223,8 +1223,10 @@ def dl(
 
     selected_plugins = filter_plugins(plugins, selected) if selected else plugins
     if disable_list:
-        disabled = {p.strip() for p in disable_list.split(",") if p.strip()}
-        selected_plugins = {k: v for k, v in selected_plugins.items() if k not in disabled}
+        disabled = {p.strip().lower() for p in disable_list.split(",") if p.strip()}
+        selected_plugins = {k: v for k, v in selected_plugins.items() if k.lower() not in disabled}
+    # Update selected to match the final plugin set so download() doesn't re-include disabled plugins
+    selected = list(selected_plugins.keys())
     install_plugins_for_phase = get_install_plugins(selected_plugins)
     crawl_setup_hooks: list[tuple[Plugin, Hook]] = []
     snapshot_hooks: list[tuple[Plugin, Hook]] = []

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -1144,6 +1144,7 @@ def cli(ctx):
 @click.option("--timeout", "-t", type=int, help="Timeout in seconds")
 @click.option("--max-urls", type=int, default=0, help="Maximum number of URLs to snapshot for this crawl (0 = unlimited)")
 @click.option("--max-size", default="0", help="Maximum total crawl size in bytes or units like 45mb / 1gb (0 = unlimited)")
+@click.option("--disable", "disable_list", help="Comma-separated list of plugins to force-disable (overrides --plugins and --output)")
 @click.option("--dry-run", is_flag=True, help="Enable abx-pkg dry-run mode and skip running snapshot hook subprocesses")
 @click.option("--no-install", "no_install", is_flag=True, help="Skip plugins with missing dependencies instead of auto-installing")
 @click.option("--debug", is_flag=True, help="Print the EventBus tree on exit or abort")
@@ -1155,6 +1156,7 @@ def dl(
     output_types: tuple[str, ...],
     output_dir: str | None,
     timeout: int | None,
+    disable_list: str | None = None,
     dry_run: bool = False,
     no_install: bool = False,
     debug: bool = False,
@@ -1177,6 +1179,8 @@ def dl(
         abx-dl --output=html,json,txt,pdf,video 'https://example.com'
 
         abx-dl -o image -o video -o text/ 'https://example.com'
+
+        abx-dl --disable=chrome,archivedotorg 'https://example.com'
 
         abx-dl --no-install 'https://example.com'
 
@@ -1218,6 +1222,9 @@ def dl(
     ui_console = stderr_console if stderr_is_tty else console
 
     selected_plugins = filter_plugins(plugins, selected) if selected else plugins
+    if disable_list:
+        disabled = {p.strip() for p in disable_list.split(",") if p.strip()}
+        selected_plugins = {k: v for k, v in selected_plugins.items() if k not in disabled}
     install_plugins_for_phase = get_install_plugins(selected_plugins)
     crawl_setup_hooks: list[tuple[Plugin, Hook]] = []
     snapshot_hooks: list[tuple[Plugin, Hook]] = []

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -1138,7 +1138,7 @@ def cli(ctx):
     "-o",
     "output_types",
     multiple=True,
-    help="Output MIME type prefixes to select plugins by (e.g. 'video,text/html'); repeatable",
+    help="Output MIME types, categories, or file extensions to select plugins by (e.g. 'video,text/html,pdf,json'); repeatable",
 )
 @click.option("--dir", "-d", "output_dir", type=click.Path(), help="Output directory")
 @click.option("--timeout", "-t", type=int, help="Timeout in seconds")
@@ -1173,6 +1173,8 @@ def dl(
         abx-dl --plugins=wget,ytdlp,git 'https://example.com'
 
         abx-dl --output=video,text/html 'https://example.com'
+
+        abx-dl --output=html,json,txt,pdf,video 'https://example.com'
 
         abx-dl -o image -o video -o text/ 'https://example.com'
 

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -455,15 +455,65 @@ def discover_plugins(plugins_dir: Path = PLUGINS_DIR) -> dict[str, Plugin]:
     return plugins
 
 
+def _expand_extension_to_mimetypes(token: str) -> list[str]:
+    """If *token* looks like a file extension (e.g. 'html', 'pdf'), return
+    all MIME types that map to that extension.  Returns an empty list when the
+    token is not a recognised extension (so the caller can fall back to treating
+    it as a MIME-type category prefix like 'video' -> 'video/').
+    """
+    import mimetypes
+    mimetypes.init()
+
+    ext = token if token.startswith(".") else f".{token}"
+    # types_map gives the canonical mapping; check both built-in maps
+    results: list[str] = []
+    for type_map in (mimetypes.types_map, mimetypes.common_types):
+        mt = type_map.get(ext)
+        if mt and mt not in results:
+            results.append(mt)
+    # Also try guess_type which consults user-installed MIME databases
+    guessed, _ = mimetypes.guess_type(f"file{ext}")
+    if guessed and guessed not in results:
+        results.append(guessed)
+    return results
+
+
 def plugins_matching_output(plugins: dict[str, Plugin], output_prefixes: list[str]) -> list[str]:
     """Return plugin names whose output_mimetypes match any of the given prefixes.
 
     Prefixes without a '/' get one appended so 'video' matches 'video/*'.
     Matching is bidirectional: 'video/' matches 'video/mp4', and a plugin
     declaring 'video/' matches a query for 'video/mp4'.
+
+    Bare tokens that correspond to a known file extension (e.g. 'html', 'pdf',
+    'json') are expanded to their MIME types first, so
+    ``--output=html,pdf,video`` works alongside ``--output=text/html,video/``.
     """
-    # normalize: 'video' -> 'video/', 'text/html' stays as-is
-    prefixes = [p if "/" in p else p + "/" for p in output_prefixes]
+    # Well-known top-level MIME type categories. These take priority over
+    # extension lookup (e.g. 'text' means 'text/*', not '.text' -> 'text/plain').
+    _MIME_CATEGORIES = frozenset({
+        "application", "audio", "chemical", "font", "image",
+        "message", "model", "multipart", "text", "video",
+        "x-conference",
+    })
+
+    # Expand each user-supplied token into one or more MIME-type prefixes.
+    prefixes: list[str] = []
+    for p in output_prefixes:
+        if "/" in p:
+            # Already a mimetype or category prefix like 'text/' or 'text/html'
+            prefixes.append(p)
+        elif p in _MIME_CATEGORIES:
+            # Known MIME category: 'video' -> 'video/'
+            prefixes.append(p + "/")
+        else:
+            expanded = _expand_extension_to_mimetypes(p)
+            if expanded:
+                prefixes.extend(expanded)
+            else:
+                # Unknown token without '/' — treat as category prefix as fallback
+                prefixes.append(p + "/")
+
     matched: list[str] = []
     for name, plugin in plugins.items():
         for mimetype in plugin.config.output_mimetypes:

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -489,30 +489,21 @@ def plugins_matching_output(plugins: dict[str, Plugin], output_prefixes: list[st
     'json') are expanded to their MIME types first, so
     ``--output=html,pdf,video`` works alongside ``--output=text/html,video/``.
     """
-    # Well-known top-level MIME type categories. These take priority over
-    # extension lookup (e.g. 'text' means 'text/*', not '.text' -> 'text/plain').
-    _MIME_CATEGORIES = frozenset({
-        "application", "audio", "chemical", "font", "image",
-        "message", "model", "multipart", "text", "video",
-        "x-conference",
-    })
-
     # Expand each user-supplied token into one or more MIME-type prefixes.
+    # Bare tokens are treated as *both* a category prefix ('video' -> 'video/')
+    # and a file extension ('mp4' -> 'video/mp4').  The category prefix is
+    # always added so that e.g. 'text' matches 'text/*' even though '.text'
+    # also resolves to 'text/plain'.  Spurious prefixes like 'html/' are
+    # harmless — they just won't match any plugin.
     prefixes: list[str] = []
     for p in output_prefixes:
         if "/" in p:
-            # Already a mimetype or category prefix like 'text/' or 'text/html'
             prefixes.append(p)
-        elif p in _MIME_CATEGORIES:
-            # Known MIME category: 'video' -> 'video/'
-            prefixes.append(p + "/")
         else:
-            expanded = _expand_extension_to_mimetypes(p)
-            if expanded:
-                prefixes.extend(expanded)
-            else:
-                # Unknown token without '/' — treat as category prefix as fallback
-                prefixes.append(p + "/")
+            # Always treat as a potential category prefix
+            prefixes.append(p + "/")
+            # Also expand as a file extension if possible
+            prefixes.extend(_expand_extension_to_mimetypes(p))
 
     matched: list[str] = []
     for name, plugin in plugins.items():

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -462,6 +462,7 @@ def _expand_extension_to_mimetypes(token: str) -> list[str]:
     it as a MIME-type category prefix like 'video' -> 'video/').
     """
     import mimetypes
+
     mimetypes.init()
 
     ext = token if token.startswith(".") else f".{token}"


### PR DESCRIPTION
## Summary
Enhanced the `--output` filter to accept file extensions (e.g., `html`, `pdf`, `json`) in addition to MIME type categories and full MIME types. This makes the CLI more user-friendly by allowing common file extensions to be used interchangeably with MIME type notation.

## Key Changes
- Added `_expand_extension_to_mimetypes()` function that converts file extensions to their corresponding MIME types using Python's `mimetypes` module, checking both built-in and user-installed MIME databases
- Refactored `plugins_matching_output()` to intelligently handle three types of input:
  - Full MIME types or category prefixes with `/` (e.g., `text/html`, `video/`)
  - Known MIME type categories (e.g., `video`, `text`, `image`)
  - File extensions that are expanded to MIME types (e.g., `html` → `text/html`, `pdf` → `application/pdf`)
- Added `_MIME_CATEGORIES` frozenset containing well-known top-level MIME type categories to prioritize category matching over extension lookup
- Updated CLI help text and added example usage showing file extension support

## Implementation Details
- File extension lookup is only attempted for tokens without `/` that don't match known MIME categories, providing a sensible fallback behavior
- Unknown tokens without `/` that don't match any extension still fall back to being treated as category prefixes (e.g., `foo` → `foo/`)
- The extension expansion checks multiple MIME type sources to ensure comprehensive coverage

https://claude.ai/code/session_01JDvGpmi4vFoZdXhGjMaPhF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/abx-dl/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let the `--output` filter accept file extensions (e.g., `html`, `pdf`, `json`) alongside MIME types/categories, and add a `--disable` flag to force-disable plugins. Also ensure disabled plugins can’t be re-included and update help/README plus small fixes.

- **New Features**
  - Accept file extensions in `--output`; expand via `_expand_extension_to_mimetypes()` using Python `mimetypes`, and treat bare tokens as both category prefixes and extension-derived MIME types; CLI help and README examples updated.
  - Add `--disable` to exclude plugins by name; overrides `--plugins` and `--output`.

- **Bug Fixes**
  - Enforce `--disable` end-to-end: pass `selected_plugins` to `download()` and rebuild `selected` so disabled plugins aren’t re-included by `filter_plugins()`; matching is case-insensitive.
  - Fix README typo and apply `ruff` formatting.

<sup>Written for commit f99c6ce07ec909d912a2e5a6d5b26d475865d180. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

