### PR TITLE
Fix JSONL parsing to handle non-JSON lines gracefully

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,7 +300,7 @@ jobs:
           find ./test-output -type f | head -50
 
           echo "=== Results ==="
-          cat ./test-output/index.json | jq '.'
+          grep '^{' ./test-output/index.jsonl | jq -s '.'
         env:
           ABX_PLUGINS_DIR: ${{ runner.temp }}/abx-plugins/abx_plugins/plugins
           CHROME_SANDBOX: "false"

--- a/server/server.py
+++ b/server/server.py
@@ -291,7 +291,7 @@ def get_session_jsonl(sid: str) -> list[dict[str, Any]]:
     records = []
     for line in path.read_text(errors="replace").strip().splitlines():
         line = line.strip()
-        if line:
+        if line and line.startswith("{"):
             try:
                 records.append(json.loads(line))
             except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
Updated JSONL file parsing to properly handle files containing non-JSON lines by adding validation checks before attempting to parse each line.

## Key Changes
- **server/server.py**: Added a check to ensure lines start with `{` before attempting JSON parsing in `get_session_jsonl()`, preventing errors from malformed or non-JSON content
- **.github/workflows/test.yml**: Updated the test output processing to filter for valid JSON lines (lines starting with `{`) before aggregating results with `jq`

## Implementation Details
The changes ensure that JSONL files (which may contain logging output, comments, or other non-JSON content) are parsed robustly by:
1. Validating that each line is a potential JSON object before parsing
2. Gracefully skipping invalid lines rather than failing on them
3. Maintaining consistency between the server-side parsing logic and the CI/CD test result aggregation

https://claude.ai/code/session_01X3T25xmA2qxuVVaXrKtyzS
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/abx-dl/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make JSONL parsing more robust by skipping non-JSON lines and updating CI to read the correct `.jsonl` file. This prevents parse errors when logs mix with JSON and fixes the test job’s output aggregation.

- **Bug Fixes**
  - In `server/server.py`, `get_session_jsonl()` now only parses lines that start with `{`; invalid lines are skipped.
  - In `.github/workflows/test.yml`, read `index.jsonl` and filter valid JSON lines with `grep '^{` before aggregating with `jq -s`.

<sup>Written for commit a100b752c6ce3a50b4ef51aed61704f2e05129d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

