### PR TITLE
Use current abxpkg install_root kwarg and unpin abx-plugins in lock cutoff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           PYTHONPATH: ${{ runner.temp }}/abx-plugins:${{ runner.temp }}/abxpkg
         run: |
-          uv sync --no-sources --extra dev
+          uv sync --no-sources --group dev
           uv pip install -e "${{ runner.temp }}/abxpkg" -e "${{ runner.temp }}/abx-plugins[dev]"
 
       - name: Run prek
@@ -90,7 +90,7 @@ jobs:
         env:
           PYTHONPATH: ${{ runner.temp }}/abx-plugins:${{ runner.temp }}/abxpkg
         run: |
-          uv sync --no-sources --extra dev
+          uv sync --no-sources --group dev
           uv pip install -e "${{ runner.temp }}/abxpkg" -e "${{ runner.temp }}/abx-plugins[dev]"
 
       - name: Run repo test suite
@@ -202,7 +202,7 @@ jobs:
         env:
           PYTHONPATH: ${{ runner.temp }}/abx-plugins:${{ runner.temp }}/abxpkg
         run: |
-          uv sync --no-sources --extra dev
+          uv sync --no-sources --group dev
           uv pip install -e "${{ runner.temp }}/abxpkg" -e "${{ runner.temp }}/abx-plugins[dev]"
 
       - name: Verify Chromium launch
@@ -286,7 +286,7 @@ jobs:
         env:
           PYTHONPATH: ${{ runner.temp }}/abx-plugins:${{ runner.temp }}/abxpkg
         run: |
-          uv sync --no-sources --extra dev
+          uv sync --no-sources --group dev
           uv pip install -e "${{ runner.temp }}/abxpkg" -e "${{ runner.temp }}/abx-plugins[dev]"
 
       - name: Verify Chromium launch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ abx-dl is a CLI tool for downloading URLs using ArchiveBox plugins. Plugins are 
 
 ```bash
 # Install dependencies
-uv sync --extra dev
+uv sync --group dev
 
 # Activate venv (or use uv run prefix)
 source .venv/bin/activate

--- a/abx_dl/dependencies.py
+++ b/abx_dl/dependencies.py
@@ -20,12 +20,12 @@ from .config import PIP_HOME, NPM_HOME
 DEFAULT_PROVIDERS: list[BinProvider] = [EnvProvider()]
 
 try:
-    DEFAULT_PROVIDERS.append(PipProvider(pip_venv=PIP_HOME / "venv"))
+    DEFAULT_PROVIDERS.append(PipProvider(install_root=PIP_HOME / "venv"))
 except Exception:
     pass
 
 try:
-    DEFAULT_PROVIDERS.append(NpmProvider(npm_prefix=NPM_HOME))
+    DEFAULT_PROVIDERS.append(NpmProvider(install_root=NPM_HOME))
 except Exception:
     pass
 

--- a/abx_dl/events.py
+++ b/abx_dl/events.py
@@ -256,12 +256,11 @@ class ProcessEvent(BaseEvent):
     def _set_background_parent_blocking(cls, data: Any) -> Any:
         if not isinstance(data, dict):
             return data
-        payload = dict(data)
-        # TODO: re-enable once abxbus BaseEvent declares the field or exposes
-        # a supported hook to opt a background child out of blocking its parent.
-        # if payload.get("is_background") and "event_blocks_parent_completion" not in payload:
-        #     payload["event_blocks_parent_completion"] = False
-        return payload
+        # TODO: mark background ProcessEvents as non-blocking for their parents
+        # once abxbus' BaseEvent declares ``event_blocks_parent_completion``
+        # (or exposes a supported hook); today it rejects unknown ``event_*``
+        # fields, which crashed any background-hook test path when injected.
+        return dict(data)
 
 
 class ProcessKillEvent(BaseEvent):

--- a/abx_dl/events.py
+++ b/abx_dl/events.py
@@ -257,8 +257,10 @@ class ProcessEvent(BaseEvent):
         if not isinstance(data, dict):
             return data
         payload = dict(data)
-        if payload.get("is_background") and "event_blocks_parent_completion" not in payload:
-            payload["event_blocks_parent_completion"] = False
+        # TODO: re-enable once abxbus BaseEvent declares the field or exposes
+        # a supported hook to opt a background child out of blocking its parent.
+        # if payload.get("is_background") and "event_blocks_parent_completion" not in payload:
+        #     payload["event_blocks_parent_completion"] = False
         return payload
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ testpaths = [ "tests", "server/tests" ]
 
 [tool.uv]
 exclude-newer = "5 days"
-exclude-newer-package = { abx-dl = "1 second", abxpkg = "1 second", abxbus = "1 second" }
+exclude-newer-package = { abx-dl = "1 second", abxpkg = "1 second", abxbus = "1 second", abx-plugins = "1 second" }
 
 [tool.mypy]
 mypy_path = "abx_dl,tests,server,abx_dl/typings"

--- a/uv.lock
+++ b/uv.lock
@@ -3,22 +3,23 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-03-28T19:04:13.87785Z"
+exclude-newer = "2026-04-16T06:17:11.325721481Z"
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
-abx-dl = { timestamp = "2026-04-02T19:04:12.877961Z", span = "PT1S" }
-abxpkg = { timestamp = "2026-04-02T19:04:12.878421Z", span = "PT1S" }
-abxbus = { timestamp = "2026-04-02T19:04:12.878422Z", span = "PT1S" }
+abxbus = { timestamp = "2026-04-21T06:17:10.32575284Z", span = "PT1S" }
+abx-dl = { timestamp = "2026-04-21T06:17:10.325739647Z", span = "PT1S" }
+abx-plugins = { timestamp = "2026-04-21T06:17:10.325753269Z", span = "PT1S" }
+abxpkg = { timestamp = "2026-04-21T06:17:10.325752366Z", span = "PT1S" }
 
 [[package]]
 name = "abx-dl"
-version = "1.10.21"
+version = "1.10.30"
 source = { editable = "." }
 dependencies = [
-    { name = "abxpkg" },
     { name = "abx-plugins" },
     { name = "abxbus" },
+    { name = "abxpkg" },
     { name = "jambo" },
     { name = "platformdirs" },
     { name = "psutil" },
@@ -29,175 +30,95 @@ dependencies = [
     { name = "rich-click" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "flake8" },
     { name = "flask" },
     { name = "mypy" },
+    { name = "prek" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-httpserver" },
     { name = "pytest-xdist" },
-    { name = "ruff" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "flask" },
-    { name = "prek" },
-    { name = "pyright" },
     { name = "ruff" },
     { name = "ty" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "abxpkg", editable = "../abxpkg" },
-    { name = "abx-plugins", editable = "../abx-plugins" },
-    { name = "abxbus", editable = "../abxbus" },
-    { name = "flake8", marker = "extra == 'dev'", specifier = ">=7.1.1" },
-    { name = "flask", marker = "extra == 'dev'", specifier = ">=3.0" },
+    { name = "abx-plugins", specifier = ">=1.10.29" },
+    { name = "abxbus", specifier = ">=2.4.9" },
+    { name = "abxpkg", specifier = ">=1.10.5" },
     { name = "jambo", specifier = ">=0.1.7" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "psutil", specifier = ">=7.2.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-httpserver", marker = "extra == 'dev'", specifier = ">=1.1.0" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rich-click", specifier = ">=1.8.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.6" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "flake8", specifier = ">=7.1.1" },
     { name = "flask", specifier = ">=3.0" },
+    { name = "mypy", specifier = ">=1.11.2" },
     { name = "prek", specifier = ">=0.3.6" },
     { name = "pyright", specifier = ">=1.1.408" },
-    { name = "ruff", specifier = ">=0.15.7" },
-    { name = "ty", specifier = ">=0.0.24" },
-]
-
-[[package]]
-name = "abxpkg"
-version = "1.9.23"
-source = { editable = "../abxpkg" }
-dependencies = [
-    { name = "pip" },
-    { name = "platformdirs" },
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "abxpkg", extras = ["rich", "pyinfra", "ansible"], marker = "extra == 'all'" },
-    { name = "ansible", marker = "extra == 'ansible'", specifier = ">=12.3.0" },
-    { name = "ansible-core", marker = "extra == 'ansible'", specifier = ">=2.0.0" },
-    { name = "ansible-runner", marker = "extra == 'ansible'", specifier = ">=2.4.2" },
-    { name = "pip", specifier = ">=26.0.1" },
-    { name = "platformdirs", specifier = ">=4.9.2" },
-    { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pyinfra", marker = "extra == 'pyinfra'", specifier = ">=3.6.1" },
-    { name = "rich", marker = "extra == 'rich'", specifier = ">=14.0.0" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
-]
-provides-extras = ["rich", "pyinfra", "ansible", "all"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "django", specifier = ">=4.0" },
-    { name = "django-admin-data-views", specifier = ">=0.3.1" },
-    { name = "django-jsonform", specifier = ">=2.22.0" },
-    { name = "django-pydantic-field", specifier = ">=0.3.9" },
-    { name = "django-stubs", specifier = ">=5.0.0" },
-    { name = "mypy", specifier = ">=1.19.1" },
-    { name = "prek", specifier = ">=0.3.6" },
-    { name = "pyright" },
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "rich", specifier = ">=14.0.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-httpserver", specifier = ">=1.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "ruff", specifier = ">=0.15.7" },
     { name = "ty", specifier = ">=0.0.24" },
 ]
 
 [[package]]
 name = "abx-plugins"
-version = "1.10.22"
-source = { editable = "../abx-plugins" }
+version = "1.10.30"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "abxpkg" },
     { name = "jambo" },
     { name = "rich-click" },
+    { name = "uv" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "abxpkg", editable = "../abxpkg" },
-    { name = "feedparser", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "jambo", specifier = ">=0.1.7" },
-    { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.1.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.408" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
-    { name = "pytest-httpserver", marker = "extra == 'dev'", specifier = ">=1.1.0" },
-    { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28.0" },
-    { name = "rich-click", specifier = ">=1.9.7" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.2" },
-    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.18" },
+sdist = { url = "https://files.pythonhosted.org/packages/02/a9/17a58d68888ac5795262eb0a5f7321e2e52311cdc9b803bd99a259a091a7/abx_plugins-1.10.30.tar.gz", hash = "sha256:e6fa2f74a3c6ea38d6f536e4af12da756756b8598bf74369f7320ec85b310c2f", size = 554053, upload-time = "2026-04-17T17:45:22.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/d7/9a076beb52b33566af3c4f55155f2ff8413b8ca589eb553dc0e3acb95808/abx_plugins-1.10.30-py3-none-any.whl", hash = "sha256:d8a99fae45f4f3edf453738298d982c2513da23cb1c9efdccd97056654054855", size = 758782, upload-time = "2026-04-17T17:45:23.333Z" },
 ]
-provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "prek", specifier = ">=0.3.6" }]
 
 [[package]]
 name = "abxbus"
-version = "2.4.10"
-source = { editable = "../abxbus" }
+version = "2.4.9"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "anyio" },
+    { name = "portalocker" },
     { name = "pydantic" },
     { name = "typing-extensions" },
     { name = "uuid7" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiofiles", specifier = ">=24.1.0" },
-    { name = "anyio", specifier = ">=4.9.0" },
-    { name = "asyncpg", marker = "extra == 'bridges'", specifier = ">=0.31.0" },
-    { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.31.0" },
-    { name = "nats-py", marker = "extra == 'bridges'", specifier = ">=2.13.1" },
-    { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.13.1" },
-    { name = "pydantic", specifier = ">=2.11.5" },
-    { name = "redis", marker = "extra == 'bridges'", specifier = ">=7.1.1" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=7.1.1" },
-    { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "uuid7", specifier = ">=0.1.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/56/bf/3341d60838432dd391b812b557b1e1d5f5d367fab87fbbd16d0ecc268b76/abxbus-2.4.9.tar.gz", hash = "sha256:af2942c972d8f828346579d647a5466990d8469a3bb3727047d01d84c250879e", size = 116437, upload-time = "2026-03-23T19:34:46.556Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/d7/29a3823e93c8eaaca62a00cdb985c873cba7553e2b45870a1828f69908ed/abxbus-2.4.9-py3-none-any.whl", hash = "sha256:b46098e86a49cf195963cbff8be182e834368a20868c11ad4bd3c70a4e00b257", size = 111562, upload-time = "2026-03-23T19:34:45.465Z" },
 ]
-provides-extras = ["postgres", "nats", "redis", "bridges"]
 
-[package.metadata.requires-dev]
-dev = [
-    { name = "build", specifier = ">=1.2.2" },
-    { name = "codespell", specifier = ">=2.4.1" },
-    { name = "fastapi", specifier = ">=0.118.0" },
-    { name = "ipdb", specifier = ">=0.13.13" },
-    { name = "prek", specifier = ">=0.3.3" },
-    { name = "psutil", specifier = ">=7.0.0" },
-    { name = "pyright", specifier = ">=1.1.404" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-asyncio", specifier = ">=1.1.0" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
-    { name = "pytest-httpserver", specifier = ">=1.0.8" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "pytest-xdist", specifier = ">=3.7.0" },
-    { name = "ruff", specifier = ">=0.15.1" },
-    { name = "ty", specifier = ">=0.0.1a19" },
+[[package]]
+name = "abxpkg"
+version = "1.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "rich-click" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/6f/f97bd4f0a3da6f4167f1ef855f9ca41aaccc9a184cffb74d1f17c92bdb40/abxpkg-1.10.6.tar.gz", hash = "sha256:c4dc61fae2ec74cea434fbbca213a8d634b21bf44086d08bc702129b790962b5", size = 187769, upload-time = "2026-04-15T03:12:00.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/92/9bb3e2c9d16d4385a181e439fb53a2ccfa7ae04e765740e7d7445724acc3/abxpkg-1.10.6-py3-none-any.whl", hash = "sha256:6f0239a8eba1c51c953d1abb7ed0351f06382928d26b8c8ddb1a9716b22487c9", size = 205413, upload-time = "2026-04-15T03:11:59.462Z" },
 ]
 
 [[package]]
@@ -787,6 +708,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
 name = "prek"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1055,6 +988,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1304,6 +1256,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/19/7472bd526591e2192926247109dbf78692e709d3e56775792fec877a7720/uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c", size = 14052, upload-time = "2021-12-29T01:38:21.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/77/8852f89a91453956582a85024d80ad96f30a41fed4c2b3dce0c9f12ecc7e/uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61", size = 7477, upload-time = "2021-12-29T01:38:20.418Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/7d/17750123a8c8e324627534fe1ae2e7a46689db8492f1a834ab4fd229a7d8/uv-0.11.7.tar.gz", hash = "sha256:46d971489b00bdb27e0aa715e4a5cd4ef2c28ea5b6ef78f2b67bf861eb44b405", size = 4083385, upload-time = "2026-04-15T21:42:55.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/5b/2bb2ab6fe6c78c2be10852482ef0cae5f3171460a6e5e24c32c9a0843163/uv-0.11.7-py3-none-linux_armv6l.whl", hash = "sha256:f422d39530516b1dfb28bb6e90c32bb7dacd50f6a383cd6e40c1a859419fbc8c", size = 23757265, upload-time = "2026-04-15T21:43:14.494Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f5/36ff27b01e60a88712628c8a5a6003b8e418883c24e084e506095844a797/uv-0.11.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8b2fe1ec6775dad10183e3fdce430a5b37b7857d49763c884f3a67eaa8ca6f8a", size = 23184529, upload-time = "2026-04-15T21:42:30.225Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/f379be661316698f877e78f4c51e5044be0b6f390803387237ad92c4057f/uv-0.11.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:162fa961a9a081dcea6e889c79f738a5ae56507047e4672964972e33c301bea9", size = 21780167, upload-time = "2026-04-15T21:42:44.942Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/fbed29775b0612f4f5679d3226268f1a347161abc1727b4080fb41d9f46f/uv-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5985a15a92bd9a170fc1947abb1fbc3e9828c5a430ad85b5bed8356c20b67a71", size = 23609640, upload-time = "2026-04-15T21:42:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/de/989a69634a869a22322770120557c2d8cbba5b77ec7cfad326b4ec0f0547/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:fab0bb43fbbc0ee5b5fee212078d2300c371b725faff7cf72eeaafa0bff0606b", size = 23322484, upload-time = "2026-04-15T21:43:26.52Z" },
+    { url = "https://files.pythonhosted.org/packages/24/08/c1af05ea602eb4eb75d86badb6b0594cc104c3ca83ccf06d9ed4dd2186ad/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:23d457d6731ebdb83f1bffebe4894edab2ef43c1ec5488433c74300db4958924", size = 23326385, upload-time = "2026-04-15T21:42:41.32Z" },
+    { url = "https://files.pythonhosted.org/packages/68/99/e246962da06383e992ecab55000c62a50fb36efef855ea7264fad4816bf4/uv-0.11.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d6a17507b8139b8803f445a03fd097f732ce8356b1b7b13cdb4dd8ef7f4b2e0", size = 24985751, upload-time = "2026-04-15T21:42:37.777Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/b0b68083859579ce811996c1480765ec6a2442b44c451eaef53e6218fbae/uv-0.11.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd48823ca4b505124389f49ae50626ba9f57212b9047738efc95126ed5f3844d", size = 25724160, upload-time = "2026-04-15T21:43:18.762Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/19/5970e89d9e458fd3c4966bbc586a685a1c0ab0a8bf334503f63fa20b925b/uv-0.11.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb91f52ee67e10d5290f2c2897e2171357f1a10966de38d83eefa93d96843b0c", size = 25028512, upload-time = "2026-04-15T21:43:02.721Z" },
+    { url = "https://files.pythonhosted.org/packages/83/eb/4e1557daf6693cb446ed28185664ad6682fd98c6dbac9e433cbc35df450a/uv-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e4d5e31bea86e1b6e0f5a0f95e14e80018e6f6c0129256d2915a4b3d793644d", size = 24933975, upload-time = "2026-04-15T21:42:18.828Z" },
+    { url = "https://files.pythonhosted.org/packages/68/55/3b517ec8297f110d6981f525cccf26f86e30883fbb9c282769cffbcdcfca/uv-0.11.7-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ceae53b202ea92bc954759bc7c7570cdcd5c3512fce15701198c19fd2dfb8605", size = 23706403, upload-time = "2026-04-15T21:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/30/7d93a0312d60e147722967036dc8ea37baab4802784bddc22464cb707deb/uv-0.11.7-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:f97e9f4e4d44fb5c4dfaa05e858ef3414a96416a2e4af270ecd88a3e5fb049a9", size = 24495797, upload-time = "2026-04-15T21:42:26.538Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/89/d49480bdab7725d36982793857e461d471bde8e1b7f438ffccee677a7bf8/uv-0.11.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:750ee5b96959b807cf442b73dd8b55111862d63f258f896787ea5f06b68aaca9", size = 24580471, upload-time = "2026-04-15T21:42:52.871Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/9f/c57dc03b48be17b564e304eb9ff982890c12dfb888b1ce370788733329ab/uv-0.11.7-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f394331f0507e80ee732cb3df737589de53bed999dd02a6d24682f08c2f8ac4f", size = 24113637, upload-time = "2026-04-15T21:42:34.094Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ba/b87e358b629a68258527e3490e73b7b148770f4d2257842dea3b7981d4e8/uv-0.11.7-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0df59ab0c6a4b14a763e8445e1c303af9abeb53cdfa4428daf9ff9642c0a3cce", size = 25119850, upload-time = "2026-04-15T21:43:22.529Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/74/16d229e1d8574bcbafa6dc643ac20b70c3e581f42ac31a6f4fd53035ffe3/uv-0.11.7-py3-none-win32.whl", hash = "sha256:553e67cc766d013ce24353fecd4ea5533d2aedcfd35f9fac430e07b1d1f23ed4", size = 22918454, upload-time = "2026-04-15T21:42:58.702Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/1d/b73e473da616ac758b8918fb218febcc46ddf64cba9e03894dfa226b28bd/uv-0.11.7-py3-none-win_amd64.whl", hash = "sha256:5674dfb5944513f4b3735b05c2deba6b1b01151f46729d533d413a9a905f8c5d", size = 25447744, upload-time = "2026-04-15T21:42:48.813Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/e6bfdea92ed270f3445a5a3c17599d041b3f2dbc5026c09e02830a03bbaf/uv-0.11.7-py3-none-win_arm64.whl", hash = "sha256:6158b7e39464f1aa1e040daa0186cae4749a78b5cd80ac769f32ca711b8976b1", size = 23941816, upload-time = "2026-04-15T21:43:06.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `abx_dl/dependencies.py`: the default `PipProvider(pip_venv=…)` / `NpmProvider(npm_prefix=…)` constructor kwargs were validation aliases that pyright no longer recognises. Swapped both to the canonical `install_root=…` kwarg so `prek`'s pyright step passes without touching runtime behaviour.
- `pyproject.toml`: add `abx-plugins = "1 second"` to `tool.uv.exclude-newer-package`. With the prior 5-day cutoff, `uv sync` got stuck on `abx-plugins==1.10.29`, whose transitive metadata still requires the pre-rename `abx-pkg` package. The lockfile refresh rides with the pyproject change so CI's `uv sync` is immediately satisfiable.

## Test plan

- [x] `uv run prek run --all-files` — clean
- [x] `uv sync --all-extras --all-groups --no-cache` — resolves without the previous `abx-pkg was not found in the package registry` failure
- [ ] CI matrix (paired with the matching `abxpkg` + `abx-plugins` branches)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/abx-dl/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch default `PipProvider`/`NpmProvider` to `install_root` so pyright passes, and remove `event_blocks_parent_completion` injection (validator is now a no-op) to avoid `abxbus` validation errors. Add `abx-plugins = "1 second"` to `tool.uv.exclude-newer-package`, refresh `uv.lock` to pick up `abxpkg`-based releases, and update CI and `CLAUDE.md` to use `uv sync --group dev` with `uv` 0.11.

<sup>Written for commit 1b13352a8ef8a7989e1cd80c635352d827ae9edf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

