### PR TITLE
output_files: strip +x bits and neutralize escaping symlinks during scan

### DIFF
--- a/abx_dl/output_files.py
+++ b/abx_dl/output_files.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import mimetypes
+import os
 import stat
 from pathlib import Path
 from collections.abc import Iterable
@@ -15,6 +16,9 @@ for strict in (True, False):
 
 
 OUTPUT_FILE_METADATA_SUFFIXES = (".stdout.log", ".stderr.log", ".log", ".pid", ".sh")
+
+EXECUTABLE_BITS = 0o111
+BROKEN_SYMLINK_SUFFIX = ".broken-symlink.txt"
 
 
 class OutputFile(BaseModel):
@@ -59,9 +63,20 @@ def output_file_from_path(file_path: Path, *, relative_to: Path) -> OutputFile:
 
 
 def scan_output_files(output_dir: Path, file_paths: Iterable[Path] | None = None) -> list[OutputFile]:
-    """Collect metadata for real hook output files, excluding process artifacts."""
+    """Collect metadata for real hook output files, excluding process artifacts.
+
+    Also sanitizes the tree as it walks: strips +x from regular files, and
+    replaces symlinks whose target escapes ``output_dir`` with a plain-text
+    ``{name}.broken-symlink.txt`` sibling holding the original target string.
+    Both operations are naturally idempotent.
+    """
     if not output_dir.is_dir():
         return []
+
+    try:
+        containment_root = output_dir.resolve()
+    except OSError:
+        containment_root = output_dir
 
     paths = output_dir.rglob("*") if file_paths is None else file_paths
     output_files = []
@@ -70,8 +85,16 @@ def scan_output_files(output_dir: Path, file_paths: Iterable[Path] | None = None
             stat_result = file_path.lstat()
         except OSError:
             continue
-        if stat.S_ISLNK(stat_result.st_mode) or not stat.S_ISREG(stat_result.st_mode):
+        if stat.S_ISLNK(stat_result.st_mode):
+            _neutralize_escaping_symlink(file_path, containment_root)
             continue
+        if not stat.S_ISREG(stat_result.st_mode):
+            continue
+        if stat_result.st_mode & EXECUTABLE_BITS:
+            try:
+                file_path.chmod(stat_result.st_mode & ~EXECUTABLE_BITS)
+            except OSError:
+                pass
         relative_path = file_path.relative_to(output_dir).as_posix()
         if any(relative_path.endswith(suffix) for suffix in OUTPUT_FILE_METADATA_SUFFIXES):
             continue
@@ -79,3 +102,33 @@ def scan_output_files(output_dir: Path, file_paths: Iterable[Path] | None = None
 
     output_files.sort(key=lambda output_file: output_file.path)
     return output_files
+
+
+def _neutralize_escaping_symlink(link_path: Path, containment_root: Path) -> None:
+    """Replace a symlink whose target escapes containment_root with a text record.
+
+    Symlinks that resolve inside containment_root are left alone. Escaping links
+    are deleted and a sibling ``{name}.broken-symlink.txt`` holding the original
+    target string is written in their place — breaking the traversal while
+    preserving the forensic reference.
+    """
+    try:
+        target = os.readlink(link_path)
+    except OSError:
+        return
+    try:
+        resolved = link_path.resolve(strict=False)
+    except OSError:
+        return
+    if resolved == containment_root or resolved.is_relative_to(containment_root):
+        return
+
+    record_path = link_path.with_name(link_path.name + BROKEN_SYMLINK_SUFFIX)
+    try:
+        link_path.unlink()
+    except OSError:
+        return
+    try:
+        record_path.write_text(str(target) + "\n", encoding="utf-8")
+    except OSError:
+        pass

--- a/abx_dl/output_files.py
+++ b/abx_dl/output_files.py
@@ -94,6 +94,8 @@ def scan_output_files(output_dir: Path, file_paths: Iterable[Path] | None = None
             try:
                 file_path.chmod(stat_result.st_mode & ~EXECUTABLE_BITS)
             except OSError:
+                # Best-effort: if chmod fails (read-only FS, permission denied),
+                # leave the bit set rather than failing the whole scan.
                 pass
         relative_path = file_path.relative_to(output_dir).as_posix()
         if any(relative_path.endswith(suffix) for suffix in OUTPUT_FILE_METADATA_SUFFIXES):
@@ -131,4 +133,6 @@ def _neutralize_escaping_symlink(link_path: Path, containment_root: Path) -> Non
     try:
         record_path.write_text(str(target) + "\n", encoding="utf-8")
     except OSError:
+        # Forensic record is best-effort; the symlink itself has already been
+        # removed above, so sanitization has succeeded even if we can't write.
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ ignore = ["E731", "E303", "E266", "E241", "E222"]
 testpaths = [ "tests", "server/tests" ]
 
 [tool.uv]
+required-version = ">=0.10.0"
 exclude-newer = "5 days"
 exclude-newer-package = { abx-dl = "1 second", abxpkg = "1 second", abxbus = "1 second", abx-plugins = "1 second" }
 

--- a/tests/test_output_files.py
+++ b/tests/test_output_files.py
@@ -1,3 +1,5 @@
+import os
+import stat
 from pathlib import Path
 
 from abx_dl.output_files import scan_output_files
@@ -16,3 +18,59 @@ def test_scan_output_files_excludes_symlinked_files_and_dirs(tmp_path: Path) -> 
 
     assert [output_file.path for output_file in output_files] == ["real.txt", "target-dir/nested.txt"]
     assert sum(output_file.size for output_file in output_files) == len("hello") + len("world")
+
+
+def test_scan_output_files_strips_executable_bits(tmp_path: Path) -> None:
+    script = tmp_path / "script.sh.x"
+    script.write_text("#!/bin/sh\necho hi\n")
+    script.chmod(0o755)
+
+    scan_output_files(tmp_path)
+
+    assert not stat.S_IMODE(script.lstat().st_mode) & 0o111
+
+
+def test_scan_output_files_neutralizes_symlink_that_escapes(tmp_path: Path) -> None:
+    snap_dir = tmp_path / "snap"
+    snap_dir.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+
+    escaping_link = snap_dir / "leak"
+    escaping_link.symlink_to(outside)
+
+    scan_output_files(snap_dir)
+
+    assert not escaping_link.exists() and not escaping_link.is_symlink()
+    record = snap_dir / "leak.broken-symlink.txt"
+    assert record.is_file() and not record.is_symlink()
+    assert record.read_text().strip() == str(outside)
+
+
+def test_scan_output_files_leaves_internal_symlinks_alone(tmp_path: Path) -> None:
+    inside = tmp_path / "real.txt"
+    inside.write_text("hi")
+    internal_link = tmp_path / "alias"
+    internal_link.symlink_to(inside)
+
+    scan_output_files(tmp_path)
+
+    assert internal_link.is_symlink()
+    assert os.readlink(internal_link) == str(inside)
+    assert not (tmp_path / "alias.broken-symlink").exists()
+
+
+def test_scan_output_files_symlink_neutralization_is_idempotent(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.txt"
+    outside.write_text("x")
+    snap_dir = tmp_path / "snap"
+    snap_dir.mkdir()
+    (snap_dir / "leak").symlink_to(outside)
+
+    scan_output_files(snap_dir)
+    scan_output_files(snap_dir)
+
+    record = snap_dir / "leak.broken-symlink.txt"
+    assert record.is_file() and not record.is_symlink()
+    assert record.read_text().strip() == str(outside)
+    assert not (snap_dir / "leak").exists()


### PR DESCRIPTION
## Summary

Apply two basic security constraints to snapshot output as it is walked, inline in the existing `scan_output_files()` function — no new events, services, state files, or config knobs.

- **Strip `+x`** from any regular file: `os.chmod(mode & ~0o111)`. Prevents archived downloads from retaining the executable bit regardless of what the source plugin (git clone, wget, etc.) wrote.
- **Neutralize escaping symlinks**: when a symlink's `resolve()` target falls outside the scan root, delete the symlink and write a plain-text `{name}.broken-symlink.txt` sibling containing the original `readlink()` target. Symlinks that stay inside the scan root are left alone. Breaks the traversal without losing the forensic reference.

Both operations are naturally idempotent — a second pass is a no-op (already-non-exec files have nothing to strip; the symlink has been replaced with a plain file on the first pass).

## Design notes

Kept the scope intentionally narrow per discussion:

- **No new sanitization state or watermark file.** The existing `scan_output_files()` call sites (on every `ProcessStdoutEvent` with an inline `ArchiveResult` record, and whenever else the function is called) give "close to generation time" enforcement for free. A sweeper / mtime cache would add complexity for a marginal window.
- **No new `SNAPSHOT_MAX_SIZE` / `SNAPSHOT_MAX_FILE_COUNT` knobs.** The existing `MAX_SIZE` / `MAX_URLS` crawl-wide limits cover the "runaway snapshot" threat model; a second ceiling would be redundant.
- **Known gap left intentionally:** a silent long-running `.bg.` hook that writes gigabytes without emitting stdout still escapes enforcement until it exits (same as today). Revisit if this bites.
- **Secret scanning and serve-time hardening (CSP, `X-Content-Type-Options`, exec-bit enforcement at HTTP layer) belong in ArchiveBox, not here** — `abx-dl` should remain a bare-bones power-user tool.

Also pins `[tool.uv] required-version = ">=0.10.0"` so the existing `exclude-newer = "5 days"` / `"1 second"` duration strings (a uv ≥0.10 feature) produce a clear error on older uv instead of a cryptic "failed to parse year in date" TOML parse error that was silently breaking `bin/setup_monorepo.sh` and `uv run prek run --all-files` on stale installations.

## Test plan

- [x] `uv run pytest tests/test_output_files.py` — 5/5 pass (1 existing regression + 4 new tests: +x stripping, escaping-symlink neutralization, internal-symlink preservation, idempotency)
- [x] `uv run ruff check abx_dl/output_files.py tests/test_output_files.py` — clean
- [x] `uv run prek run --all-files` — all hooks pass (ruff, ty, pyright, codespell, etc.)
- [x] Full `uv run pytest tests/` — 83 pass; 2 pre-existing environmental failures unrelated to this change (`rich._unicode_data.unicode17-0-0` import, missing `yt-dlp` binary)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JPzFByx7Yse3HETY9vrwxh)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/archivebox/abx-dl/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure snapshot output by stripping executable bits and neutralizing symlinks that point outside the scan root, done inline in `scan_output_files()`. Also pins `uv` to `>=0.10.0` to prevent duration parsing errors, and documents non-fatal OSError handling (chmod and forensic-record write) to address CodeQL; behavior unchanged.

- **New Features**
  - Strip `+x` from regular files during `scan_output_files()`; prevents executable files in archives and is idempotent.
  - Replace symlinks that resolve outside the scan root with `{name}.broken-symlink.txt` containing the original `readlink()` target; keep internal symlinks as-is.

- **Dependencies**
  - Set `[tool.uv].required-version = ">=0.10.0"` so duration strings like `"5 days"` parse correctly; avoids setup failures on older `uv` versions.

<sup>Written for commit 91932fb1936f38c235906b32c0973f3e8317a6a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

