### PR TITLE
Stream lifecycle progress without a TTY

### DIFF
--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -886,24 +886,25 @@ class LiveBusUI:
                 transient=True,
                 vertical_overflow="visible",
             )
-            for event_cls, handler in (
-                (ProcessStartedEvent, self.on_ProcessStartedEvent),
-                (ProcessStdoutEvent, self.on_ProcessStdoutEvent),
-                (BinaryRequestEvent, self.on_BinaryRequestEvent),
-                (BinaryEvent, self.on_BinaryEvent),
-                (ArchiveResultEvent, self.on_ArchiveResultEvent),
-                (ProcessCompletedEvent, self.on_ProcessCompletedEvent),
-                (CrawlPauseEvent, self.on_CrawlPauseEvent),
-                (CrawlAbortEvent, self.on_CrawlControlEvent),
-                (CrawlResumeAndRetryEvent, self.on_CrawlControlEvent),
-                (CrawlResumeAndSkipEvent, self.on_CrawlControlEvent),
-            ):
-                self.bus.on(event_cls, handler)
         else:
             self.progress = None
             self.status_view = None
             self.task_id = None
             self.live = None
+
+        for event_cls, handler in (
+            (ProcessStartedEvent, self.on_ProcessStartedEvent),
+            (ProcessStdoutEvent, self.on_ProcessStdoutEvent),
+            (BinaryRequestEvent, self.on_BinaryRequestEvent),
+            (BinaryEvent, self.on_BinaryEvent),
+            (ArchiveResultEvent, self.on_ArchiveResultEvent),
+            (ProcessCompletedEvent, self.on_ProcessCompletedEvent),
+            (CrawlPauseEvent, self.on_CrawlPauseEvent),
+            (CrawlAbortEvent, self.on_CrawlControlEvent),
+            (CrawlResumeAndRetryEvent, self.on_CrawlControlEvent),
+            (CrawlResumeAndSkipEvent, self.on_CrawlControlEvent),
+        ):
+            self.bus.on(event_cls, handler)
 
     def __enter__(self):
         if self.live is not None:
@@ -928,6 +929,7 @@ class LiveBusUI:
 
     def print_intro(self, *, url: str, output_dir: Path, plugins_label: str) -> None:
         if not self.interactive_tty:
+            self.ui_console.print(f"[STARTED] {url} -> {_abbreviate_home_paths(str(output_dir.absolute()))}")
             return
         self.ui_console.print(f"[bold blue]Downloading:[/bold blue] {url}")
         self.ui_console.print(f"[dim]Output: {_abbreviate_home_paths(str(output_dir.absolute()))}[/dim]")
@@ -936,6 +938,13 @@ class LiveBusUI:
 
     def print_summary(self, *, output_dir: Path, archive_results: list[ArchiveResultEvent]) -> None:
         if not self.interactive_tty:
+            self.ui_console.print(
+                f"[COMPLETED] {sum(1 for result in archive_results if result.status == 'succeeded')} succeeded, "
+                f"{sum(1 for result in archive_results if result.status in ('noresult', 'noresults'))} noresult, "
+                f"{sum(1 for result in archive_results if result.status == 'failed')} failed, "
+                f"{sum(1 for result in archive_results if result.status == 'skipped')} skipped -> "
+                f"{_abbreviate_home_paths(str(output_dir.absolute()))}",
+            )
             return
         self.ui_console.print()
         self.ui_console.print(
@@ -965,6 +974,12 @@ class LiveBusUI:
             ),
         )
         self.streamed_header = True
+
+    def _print_started_row(self, record: _LiveProcessRecord) -> None:
+        line = Text()
+        line.append("[STARTED]", style="green bold")
+        line.append(f" {record.phase or '-'} {record.plugin or '-'} {record.hook_name or '-'}")
+        self.ui_console.print(line)
 
     def _match_row_key(
         self,
@@ -998,8 +1013,6 @@ class LiveBusUI:
             row.status = row.final_status or row.status
 
     async def on_ProcessStartedEvent(self, event: ProcessStartedEvent) -> None:
-        if self.progress is None or self.task_id is None:
-            return
         self.process_row_num += 1
         row_key = f"process:{self.process_row_num}"
         self.row_key_by_event_id[event.event_id] = row_key
@@ -1007,7 +1020,7 @@ class LiveBusUI:
             self.row_key_by_event_id[event.event_parent_id] = row_key
         self.process_event_by_row_key[row_key] = event
         self.active_row_keys.append(row_key)
-        self.live_results[row_key] = _LiveProcessRecord(
+        row = _LiveProcessRecord(
             id=row_key,
             plugin=event.plugin_name,
             hook_name=event.hook_name,
@@ -1016,6 +1029,10 @@ class LiveBusUI:
             started_at=event.start_ts or datetime.now(UTC).isoformat(),
             cmd=[event.hook_path, *event.hook_args],
         )
+        self.live_results[row_key] = row
+        if self.progress is None or self.task_id is None:
+            self._print_started_row(row)
+            return
         current_task = self.progress.tasks[self.task_id]
         seen_hooks = max(current_task.completed + len(self.active_row_keys), 1)
         self.progress.update(self.task_id, total=seen_hooks)
@@ -1023,8 +1040,6 @@ class LiveBusUI:
         self._refresh_live()
 
     async def on_BinaryRequestEvent(self, event: BinaryRequestEvent) -> None:
-        if self.progress is None or self.task_id is None:
-            return
         plugin_name = str(event.extra_context.get("plugin_name") or "")
         row_key = self._match_row_key(event)
         if row_key is None:
@@ -1054,6 +1069,9 @@ class LiveBusUI:
         row.output = _binary_event_output(event)
         row.status = "started"
         self.live_results[row_key] = row
+        if self.progress is None or self.task_id is None:
+            self._print_started_row(row)
+            return
         current_task = self.progress.tasks[self.task_id]
         seen_hooks = max(current_task.completed + len(self.active_row_keys), 1)
         self.progress.update(self.task_id, total=seen_hooks)
@@ -1061,8 +1079,6 @@ class LiveBusUI:
         self._refresh_live(force=True)
 
     async def on_BinaryEvent(self, event: BinaryEvent) -> None:
-        if self.progress is None or self.task_id is None:
-            return
         plugin_name = str(event.extra_context.get("plugin_name") or "")
         row_key = self._match_row_key(event)
         if row_key is None:
@@ -1102,6 +1118,8 @@ class LiveBusUI:
             self.active_row_keys.remove(row_key)
         self.live_results.pop(row_key, None)
         self._print_completed_row(row)
+        if self.progress is None or self.task_id is None:
+            return
         current_task = self.progress.tasks[self.task_id]
         self.progress.update(self.task_id, total=max(current_task.completed + len(self.active_row_keys), 1))
         _advance_progress(
@@ -1134,8 +1152,6 @@ class LiveBusUI:
             existing.output = line
 
     async def on_ProcessCompletedEvent(self, event: ProcessCompletedEvent) -> None:
-        if self.progress is None or self.task_id is None:
-            return
         row_key = self._match_row_key(event)
         if row_key is None:
             row_key = f"process:completed:{len(self.live_results) + 1}"
@@ -1210,6 +1226,8 @@ class LiveBusUI:
             self.active_row_keys.remove(row_key)
         self.live_results.pop(row_key, None)
         self._print_completed_row(row)
+        if self.progress is None or self.task_id is None:
+            return
         current_task = self.progress.tasks[self.task_id]
         self.progress.update(self.task_id, total=max(current_task.completed + len(self.active_row_keys), 1))
         _advance_progress(
@@ -1383,7 +1401,7 @@ def dl(
     stdout_is_tty = sys.stdout.isatty()
     stderr_is_tty = sys.stderr.isatty()
     interactive_tty = stdout_is_tty or stderr_is_tty
-    ui_console = stderr_console if stderr_is_tty else console
+    ui_console = stderr_console if stderr_is_tty or not stdout_is_tty else console
 
     selected_plugins = filter_plugins(plugins, selected if selected else None)
     if disable_list:

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -929,7 +929,9 @@ class LiveBusUI:
 
     def print_intro(self, *, url: str, output_dir: Path, plugins_label: str) -> None:
         if not self.interactive_tty:
-            self.ui_console.print(f"[STARTED] {url} -> {_abbreviate_home_paths(str(output_dir.absolute()))}")
+            self.ui_console.print(
+                Text(f"[STARTED] {url} -> {_abbreviate_home_paths(str(output_dir.absolute()))}"),
+            )
             return
         self.ui_console.print(f"[bold blue]Downloading:[/bold blue] {url}")
         self.ui_console.print(f"[dim]Output: {_abbreviate_home_paths(str(output_dir.absolute()))}[/dim]")
@@ -939,11 +941,13 @@ class LiveBusUI:
     def print_summary(self, *, output_dir: Path, archive_results: list[ArchiveResultEvent]) -> None:
         if not self.interactive_tty:
             self.ui_console.print(
-                f"[COMPLETED] {sum(1 for result in archive_results if result.status == 'succeeded')} succeeded, "
-                f"{sum(1 for result in archive_results if result.status in ('noresult', 'noresults'))} noresult, "
-                f"{sum(1 for result in archive_results if result.status == 'failed')} failed, "
-                f"{sum(1 for result in archive_results if result.status == 'skipped')} skipped -> "
-                f"{_abbreviate_home_paths(str(output_dir.absolute()))}",
+                Text(
+                    f"[COMPLETED] {sum(1 for result in archive_results if result.status == 'succeeded')} succeeded, "
+                    f"{sum(1 for result in archive_results if result.status in ('noresult', 'noresults'))} noresult, "
+                    f"{sum(1 for result in archive_results if result.status == 'failed')} failed, "
+                    f"{sum(1 for result in archive_results if result.status == 'skipped')} skipped -> "
+                    f"{_abbreviate_home_paths(str(output_dir.absolute()))}",
+                ),
             )
             return
         self.ui_console.print()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,6 +356,31 @@ def test_noninteractive_live_ui_streams_process_lifecycle() -> None:
     assert "succeeded" in rendered
 
 
+def test_noninteractive_intro_and_summary_preserve_literal_brackets() -> None:
+    bus = create_bus(total_timeout=10.0, name="noninteractive_literal_brackets")
+    output = io.StringIO()
+    live_ui = cli_module.LiveBusUI(
+        bus,
+        total_hooks=0,
+        timeout_seconds=60,
+        ui_console=Console(file=output, force_terminal=False, color_system=None, width=200),
+        interactive_tty=False,
+    )
+    # Non-TTY output is consumed as plain logs. Rich markup-like text can be
+    # supplied by both the URL and output path, so every bracket must survive.
+    output_dir = Path("/tmp/[bold]archive[/bold]")
+    live_ui.print_intro(
+        url="https://example.com/[red]literal[/red]",
+        output_dir=output_dir,
+        plugins_label="title",
+    )
+    live_ui.print_summary(output_dir=output_dir, archive_results=[])
+
+    rendered = output.getvalue()
+    assert "[STARTED] https://example.com/[red]literal[/red] -> /tmp/[bold]archive[/bold]" in rendered
+    assert "[COMPLETED] 0 succeeded, 0 noresult, 0 failed, 0 skipped -> /tmp/[bold]archive[/bold]" in rendered
+
+
 def test_process_completed_success_ignores_stderr_for_live_output() -> None:
     bus = create_bus(total_timeout=10.0, name="process_completed_success_stderr")
     output = io.StringIO()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,67 @@ def test_process_completed_uses_last_non_json_line_for_live_output() -> None:
     assert "Starting infinite scroll on https://yahoo.com" not in rendered
 
 
+def test_noninteractive_live_ui_streams_process_lifecycle() -> None:
+    bus = create_bus(total_timeout=10.0, name="noninteractive_process_lifecycle")
+    output = io.StringIO()
+    cli_module.LiveBusUI(
+        bus,
+        total_hooks=1,
+        timeout_seconds=60,
+        ui_console=Console(file=output, force_terminal=False, color_system=None),
+        interactive_tty=False,
+    )
+
+    async def run() -> None:
+        process = await _completed_real_hook_process()
+        started_event = ProcessStartedEvent(
+            plugin_name="parse_txt_urls",
+            hook_name="on_Snapshot__71_parse_txt_urls",
+            hook_path=_real_hook_path("parse_txt_urls", "on_Snapshot__71_parse_txt_urls"),
+            hook_args=["--url=https://example.com"],
+            output_dir="/tmp",
+            env={},
+            timeout=60,
+            pid=process.pid or 0,
+            subprocess=process,
+            stdout_file=Path("/tmp/noninteractive_process_lifecycle.stdout.log"),
+            stderr_file=Path("/tmp/noninteractive_process_lifecycle.stderr.log"),
+            pid_file=Path("/tmp/noninteractive_process_lifecycle.pid"),
+            cmd_file=Path("/tmp/noninteractive_process_lifecycle.sh"),
+            files_before=set(),
+            start_ts="2026-03-25T12:00:00",
+        )
+        completed_event = ProcessCompletedEvent(
+            plugin_name=started_event.plugin_name,
+            hook_name=started_event.hook_name,
+            hook_path=started_event.hook_path,
+            hook_args=started_event.hook_args,
+            env={},
+            timeout=60,
+            stdout='{"type":"ArchiveResult","status":"succeeded","output_str":"1 URL"}\n',
+            stderr="",
+            exit_code=0,
+            status="succeeded",
+            output_dir="/tmp",
+            output_files=[],
+            start_ts=started_event.start_ts,
+            end_ts="2026-03-25T12:00:01",
+            event_parent_id=started_event.event_id,
+        )
+        await bus.emit(started_event).now()
+        await bus.emit(completed_event).now()
+        await bus.wait_until_idle()
+        await bus.destroy(clear=False)
+
+    asyncio.run(run())
+
+    rendered = output.getvalue()
+    assert "STARTED" in rendered
+    assert "parse_txt_urls" in rendered
+    assert "on_Snapshot__71_parse_txt_urls" in rendered
+    assert "succeeded" in rendered
+
+
 def test_process_completed_success_ignores_stderr_for_live_output() -> None:
     bus = create_bus(total_timeout=10.0, name="process_completed_success_stderr")
     output = io.StringIO()

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -811,6 +811,7 @@ def test_real_js_snapshot_hook_replays_early_sigterm_to_late_cleanup_handler(tmp
     chrome = discover_plugins()["chrome"]
     selected = {chrome.name: chrome, plugin.name: plugin}
     hook = plugin.hooks[0]
+    navigate_hook = next(hook for hook in chrome.filter_hooks("Snapshot") if not hook.is_background)
     bus = create_bus(total_timeout=120.0, name=f"real_js_early_sigterm_{tmp_path.name}")
     output_dir = tmp_path / "run"
 
@@ -836,6 +837,18 @@ def test_real_js_snapshot_hook_replays_early_sigterm_to_late_cleanup_handler(tmp
             where=lambda event: event.line == "staticfile listener attached",
         )
         assert isinstance(ready, ProcessStdoutEvent)
+        # The hook-ready waiter above and SnapshotService both resume from the
+        # same stdout event. Wait until the next foreground hook is published
+        # so scheduler order cannot make cleanup misclassify this as a
+        # background-only snapshot and intentionally await its natural result.
+        foreground = await bus.find(
+            ProcessEvent,
+            past=True,
+            future=60.0,
+            plugin_name=chrome.name,
+            hook_name=navigate_hook.name,
+        )
+        assert isinstance(foreground, ProcessEvent)
         snapshot_event = await bus.find(SnapshotEvent, past=True, future=False)
         assert isinstance(snapshot_event, SnapshotEvent)
         crawl = await bus.find(CrawlEvent, past=True, future=False)


### PR DESCRIPTION
## Summary

- attach lifecycle handlers in both interactive and non-interactive runs
- print each real process/binary start and completion when Rich Live cannot be used
- keep machine-readable stdout clean by sending non-TTY human progress to stderr

This fixes silent ArchiveBox supervisor workers at the shared downloader UI layer. Hook ordering remains unchanged and fully sequential/dependency-aware.

## Root cause

ArchiveBox deliberately launches foreground crawl work through a supervised child whose stdout/stderr are files. That makes the child non-TTY by construction, but LiveBusUI previously registered no handlers at all in non-TTY mode.

## Verification

- regression uses the shipped parse_txt_urls hook as a real subprocess and real EventBus lifecycle
- `uv run pytest tests/test_cli.py -q`: 54 passed
- changed-file prek hooks, ty, and pyright: passed
- verified in a real Docker ArchiveBox add: STARTED and succeeded hook rows were relayed before command completion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent lifecycle progress for non-TTY runs so ArchiveBox supervisor workers now stream STARTED and COMPLETED lines to stderr instead of nothing. Previously `LiveBusUI` only attached lifecycle handlers in interactive TTY mode; now handlers are always registered, and non-TTY progress goes to stderr so stdout stays machine-readable.

**Bug Fixes**
- Non-TTY runs print STARTED rows for process and binary starts plus a COMPLETED summary with result counts.
- Non-TTY lines are emitted as plain text so URLs and paths containing Rich markup-like brackets are preserved literally.
- Adds regression tests for the full non-TTY event-bus lifecycle and literal bracket output.

<sup>Written for commit 3cb87f825fb09188a2f27fd383b260361c11888e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-dl/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

