### PR TITLE
Keep Docker metadata out of runtime cache keys

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -223,7 +223,7 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |
             ABXBUS_VERSION=${{ env.ABXBUS_VERSION }}
-            ABXPKG_VERSION=${{ env.ABXPKG_VERSION }}
+            DIST_ABXPKG_VERSION=${{ env.ABXPKG_VERSION }}
             ABX_PLUGINS_VERSION=${{ env.ABX_PLUGINS_VERSION }}
             ABX_DL_VERSION=${{ env.ABX_DL_VERSION }}
             ABX_DL_COMMIT_HASH=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,7 @@ RUN --mount=type=cache,target=/var/tmp/abxpkg-cache,sharing=locked,mode=1777,id=
 # supplies the exact released values here so autobumps invalidate only the
 # package overlay and provenance, never the installed browser/toolchain.
 ARG ABXBUS_VERSION
-ARG ABXPKG_VERSION
+ARG DIST_ABXPKG_VERSION
 ARG ABX_PLUGINS_VERSION
 ARG ABX_DL_VERSION
 ARG ABX_DL_COMMIT_HASH
@@ -223,7 +223,7 @@ ARG ABX_DL_COMMIT_HASH
 RUN PURELIB_DIR="$(/venv/bin/python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')" \
     && for package_version in \
         "abxbus|$ABXBUS_VERSION" \
-        "abxpkg|$ABXPKG_VERSION" \
+        "abxpkg|$DIST_ABXPKG_VERSION" \
         "abx_plugins|$ABX_PLUGINS_VERSION" \
         "abx_dl|$ABX_DL_VERSION"; do \
         IFS='|' read -r package version <<< "$package_version"; \


### PR DESCRIPTION
## Summary

- rename the build-only abxpkg distribution version argument so it cannot enter the runtime `ABXPKG_*` cache identity
- preserve the exact abxpkg distribution metadata overlay

## Root cause

`ARG ABXPKG_VERSION` existed while the final image cache warm-up ran. abxpkg correctly treats `ABXPKG_*` variables as runtime configuration, so the image stored request projections keyed by a build argument that Docker removes at runtime. The ArchiveWeb.page setup hook then missed its cached Python projection and loaded the full Rich/Pydantic CLI.

## Verification

- reproduced the existing Docker check red on both GitHub architectures and a clean local image
- rebuilt the real arm64 image with exact dependency sources
- verified `abx-dl install` leaves every `derived.env` hash unchanged
- verified the ArchiveWeb.page setup hook import profile contains neither `rich_click` nor `pydantic`
- verified the image still reports abxpkg 1.12.110
- changed-file prek checks pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker cache poisoning where the `ABXPKG_VERSION` build arg leaked into runtime cache keys, causing ArchiveWeb.page to miss its cached Python projection and load the full Rich/Pydantic CLI.

Renames the build-only argument to `DIST_ABXPKG_VERSION` so `abxpkg`'s runtime config detection ignores it. Image version reporting and all derived dependency hashes remain unchanged.

<sup>Written for commit e3e6e3734695ff4e109c02ef0b694ddce9e73bb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-dl/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

