### PR TITLE
Add framework-neutral plugin runtime interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Plugins are loaded from the installed [`abx-plugins`](https://pypi.org/project/a
 2. **CrawlSetup hooks** (`on_CrawlSetup__*`) launch/configure expensive crawl-scoped processes like chrome, or trigger side effects. background hooks use their first stdout line as the readiness boundary and emit no stdout JSONL records.
 3. **Snapshot hooks** (`on_Snapshot__*`) run per URL to extract content. background hooks use their first stdout line as the readiness boundary; JSONL records after that are `ArchiveResult`, `Snapshot`, and `Tag`.
 
+Applications embedding the runtime use the same framework-free interfaces as
+the CLI: `PluginCatalog` for inventory, `PluginConfigResolver` for config,
+`ExecutionPlan` for plugin selection/service setup, `execute_hook()` for a
+single finite hook, and `OutputManifest` for output metadata. These APIs accept
+plain mappings, filesystem paths, environment variables, and CLI arguments;
+they do not depend on Django or an application database.
+
 
 <br/>
 

--- a/abx_dl/catalog.py
+++ b/abx_dl/catalog.py
@@ -1,0 +1,173 @@
+"""Generic plugin inventory and configuration interfaces for embedders.
+
+The catalog knows only about plugin directories, declarative manifests, and
+hook files.  It deliberately has no persistence or application-framework
+integration; applications such as ArchiveBox can keep those concerns in their
+own adapters while sharing the exact inventory used by the downloader CLI.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from abx_plugins.plugins.base import utils as plugin_utils
+
+from .models import Hook, Plugin, discover_plugins, filter_plugins
+
+
+@dataclass(frozen=True)
+class PluginCatalog(Mapping[str, Plugin]):
+    """One immutable view of discovered plugins and their manifests."""
+
+    plugins: dict[str, Plugin]
+
+    @classmethod
+    def discover(
+        cls,
+        plugins_dir: Path | None = None,
+        *,
+        extra_plugin_dirs: Iterable[Path] = (),
+        runtime: str | None = None,
+    ) -> PluginCatalog:
+        plugins = discover_plugins(plugins_dir=plugins_dir, runtime=runtime)
+        for extra_dir in extra_plugin_dirs:
+            plugins.update(discover_plugins(plugins_dir=extra_dir, runtime=runtime))
+        return cls(plugins)
+
+    def __getitem__(self, name: str) -> Plugin:
+        return self.plugins[name]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.plugins)
+
+    def __len__(self) -> int:
+        return len(self.plugins)
+
+    @property
+    def schemas(self) -> dict[str, dict[str, Any]]:
+        """Return complete config.json documents keyed by plugin name."""
+        return {name: dict(plugin.manifest) for name, plugin in self.plugins.items() if plugin.manifest}
+
+    @property
+    def properties(self) -> dict[str, dict[str, Any]]:
+        """Return the flattened config-property schema owned by the catalog."""
+        properties: dict[str, dict[str, Any]] = {}
+        for schema in self.schemas.values():
+            for key, definition in (schema.get("properties") or {}).items():
+                if isinstance(definition, dict):
+                    properties[str(key)] = definition
+        return properties
+
+    def select(self, names: list[str] | None = None, *, disabled_names: list[str] | None = None) -> PluginCatalog:
+        return type(self)(filter_plugins(self.plugins, names, disabled_names=disabled_names))
+
+    def hooks(
+        self,
+        event_name: str,
+        *,
+        names: list[str] | None = None,
+        disabled_names: list[str] | None = None,
+    ) -> list[tuple[Plugin, Hook]]:
+        """Return dependency-expanded hooks in their canonical execution order."""
+        event_name = event_name.removesuffix("Event")
+        selected = self.select(names, disabled_names=disabled_names)
+        hooks = [(plugin, hook) for plugin in selected.values() for hook in plugin.filter_hooks(event_name)]
+        return sorted(hooks, key=lambda item: item[1].sort_key)
+
+    def groups(self, *, include_hidden: bool = False) -> dict[str, list[Plugin]]:
+        """Group plugins by generic manifest category for presentation clients."""
+        grouped: dict[str, list[Plugin]] = defaultdict(list)
+        for plugin in self.plugins.values():
+            if plugin.config.hidden and not include_hidden:
+                continue
+            grouped[plugin.config.category or "other"].append(plugin)
+        return {
+            category: sorted(plugins, key=lambda plugin: (plugin.config.display_order, plugin.name))
+            for category, plugins in grouped.items()
+        }
+
+    def template_path(self, plugin_name: str, template_name: str) -> Path | None:
+        """Return a plugin-owned presentation asset without interpreting it."""
+        template = self.plugins[plugin_name].path / "templates" / f"{template_name}.html"
+        return template if template.is_file() else None
+
+
+@dataclass(frozen=True)
+class PluginConfigResolver:
+    """Resolve declarative plugin schemas without application-framework state."""
+
+    catalog: PluginCatalog
+
+    @property
+    def schemas(self) -> dict[str, dict[str, Any]]:
+        return self.catalog.schemas
+
+    @property
+    def properties(self) -> dict[str, dict[str, Any]]:
+        return self.catalog.properties
+
+    def canonical_key(self, key: str) -> str:
+        return plugin_utils.resolve_alias(key, self.schemas)
+
+    def resolve(
+        self,
+        *,
+        global_config: Mapping[str, Any] | None = None,
+        user_config: Mapping[str, Any] | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        return plugin_utils.resolve_plugin_configs(
+            self.schemas,
+            global_config=dict(global_config or {}),
+            user_config=dict(user_config or {}),
+            environ=dict(environ or {}),
+        )
+
+    def enabled_plugin_names(
+        self,
+        *,
+        resolved: Mapping[str, Mapping[str, Any]] | None = None,
+        global_config: Mapping[str, Any] | None = None,
+        user_config: Mapping[str, Any] | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> list[str]:
+        """Return enabled plugins with required-plugin dependencies expanded."""
+        resolved_config = resolved or self.resolve(
+            global_config=global_config,
+            user_config=user_config,
+            environ=environ,
+        )
+        enabled: list[str] = []
+        disabled: list[str] = []
+        for name, plugin in self.catalog.items():
+            enabled_key = plugin.enabled_key
+            value = resolved_config.get(name, {}).get(enabled_key, True)
+            if isinstance(value, str):
+                value = value.strip().lower() not in {"", "0", "false", "no", "off"}
+            (enabled if value else disabled).append(name)
+        return list(self.catalog.select(enabled, disabled_names=disabled))
+
+    def enabled_plugin_names_from_flat(self, config: Mapping[str, Any]) -> list[str]:
+        """Select plugins from an already-resolved flat application config."""
+        enabled: list[str] = []
+        disabled: list[str] = []
+        for name, plugin in self.catalog.items():
+            value = config.get(plugin.enabled_key, True)
+            if isinstance(value, str):
+                value = value.strip().lower() not in {"", "0", "false", "no", "off"}
+            (enabled if value else disabled).append(name)
+        return list(self.catalog.select(enabled, disabled_names=disabled))
+
+    def runtime_settings(self, plugin_name: str, config: Mapping[str, Any], *, default_timeout: int = 300) -> dict[str, Any]:
+        """Return conventional enabled/timeout/binary values for one plugin."""
+        plugin = self.catalog[plugin_name]
+        enabled_value = config.get(plugin.enabled_key, True)
+        if isinstance(enabled_value, str):
+            enabled_value = enabled_value.strip().lower() not in {"", "0", "false", "no", "off"}
+        timeout = config.get(f"{plugin_name.upper()}_TIMEOUT") or config.get("TIMEOUT", default_timeout)
+        binary = config.get(f"{plugin_name.upper()}_BINARY", plugin_name)
+        return {"enabled": bool(enabled_value), "timeout": int(timeout), "binary": str(binary)}

--- a/abx_dl/execution.py
+++ b/abx_dl/execution.py
@@ -1,0 +1,83 @@
+"""Framework-free execution entry points for individual plugin hooks."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from abxbus import EventBus
+
+from .events import ProcessCompletedEvent, ProcessEvent, slow_warning_timeout
+from .models import Hook
+from .orchestrator import create_bus
+from .services.process_service import ProcessService
+
+
+def build_hook_args(values: Mapping[str, Any]) -> list[str]:
+    """Encode application-owned values using the standalone hook CLI contract."""
+    args: list[str] = []
+    for key, value in values.items():
+        if key.startswith("_") or value is None or value == "" or value is False:
+            continue
+        name = f"--{key.replace('_', '-')}"
+        if value is True:
+            args.append(name)
+        elif isinstance(value, (dict, list)):
+            args.append(f"{name}={json.dumps(value)}")
+        else:
+            rendered = str(value).strip()
+            if rendered:
+                args.append(f"{name}={rendered}")
+    return args
+
+
+async def execute_hook(
+    hook: Hook,
+    *,
+    output_dir: Path,
+    env: Mapping[str, str],
+    arguments: Mapping[str, Any] | None = None,
+    timeout: int = 60,
+    bus: EventBus | None = None,
+    attach_process_service: bool = True,
+    process_type: str = "hook",
+    worker_type: str = "",
+) -> ProcessCompletedEvent:
+    """Execute one finite hook and return its canonical completion event.
+
+    Embedders provide only filesystem, environment, and CLI inputs. They may
+    attach their own event projectors to ``bus`` without making this API aware
+    of an application framework or database.
+    """
+    if hook.is_background:
+        raise ValueError("execute_hook() requires a finite foreground hook")
+
+    event_bus = bus or create_bus(total_timeout=float(timeout) + 30.0, name="AbxDlHook")
+    if attach_process_service:
+        ProcessService(event_bus, emit_jsonl=False, interactive_tty=False)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    process_event = ProcessEvent(
+        plugin_name=hook.plugin_name,
+        hook_name=hook.name,
+        hook_path=str(hook.path),
+        hook_args=build_hook_args(arguments or {}),
+        is_background=False,
+        output_dir=str(output_dir),
+        env=dict(env),
+        timeout=timeout,
+        process_type=process_type,
+        worker_type=worker_type,
+        url=str((arguments or {}).get("url") or ""),
+        event_timeout=float(timeout) + 30.0,
+        event_handler_timeout=float(timeout) + 30.0,
+        event_handler_slow_timeout=slow_warning_timeout(float(timeout) + 30.0),
+    )
+    emitted = event_bus.emit(process_event)
+    await emitted.now(timeout=float(timeout) + 30.0)
+    completed = await event_bus.find(ProcessCompletedEvent, child_of=emitted, past=True, future=False)
+    if completed is None:
+        raise RuntimeError(f"Hook {hook.full_name} finished without a ProcessCompletedEvent")
+    return completed

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -366,19 +366,20 @@ PLUGINS_DIR = _default_plugins_dir()
 def parse_hook_filename(filename: str) -> tuple[str, int, bool] | None:
     """Parse a hook filename to extract (event_type, order, is_background).
 
-    Format: `on_{Event}__[{order}_]{description}[.bg].{ext}`
+    Format: `on_{Event}__[{order}_]{description}[.bg].{ext}`. The legacy
+    `__background` marker remains supported for existing user plugins.
 
     Returns None if the filename doesn't match the hook convention.
     Never attempt to determine .finite/.daemon/interpreter, hooks should be treated like black-box executables.
     """
     pattern = r"^on_(\w+)__(?:(\d+)_)?(.+)$"
-    match = re.match(pattern, filename)
+    match = re.match(pattern, filename.replace("__background", ""))
     if not match:
         return None
 
     event = match.group(1)
     order = int(match.group(2) or 0)
-    is_background = ".bg." in filename
+    is_background = ".bg." in filename or "__background" in Path(filename).stem
 
     return (event, order, is_background)
 

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -99,12 +99,16 @@ class PluginConfig(BaseModel):
     title: str = ""
     description: str = ""
     x_runtimes: list[str] = Field(default_factory=list, alias="x-runtimes")
+    x_auto_run: bool = Field(default=True, alias="x-auto-run")
     x_accepts_internal_input: bool = Field(default=False, alias="x-accepts-internal-input")
     output_mimetypes: list[str] = Field(default_factory=list)  # e.g. ['text/html', 'video/']
     properties: dict[str, dict[str, Any]] = Field(default_factory=dict)  # JSONSchema format describing plugin config
     required_binaries: list[RequiredBinary] = Field(default_factory=list)  # e.g. [{'name': 'wget', 'binproviders': 'env,brew,apt'}]
     required_plugins: list[str] = Field(default_factory=list)  # e.g. ['chrome', 'pdf']
     wait_for_plugins: list[str] = Field(default_factory=list)
+    category: str = ""
+    display_order: int = 1000
+    hidden: bool = False
 
 
 class Plugin(BaseModel):
@@ -122,6 +126,7 @@ class Plugin(BaseModel):
     name: str
     path: Path
     config: PluginConfig = Field(default_factory=PluginConfig)
+    manifest: dict[str, Any] = Field(default_factory=dict)
     hooks: list[Hook] = Field(default_factory=list)
 
     @property
@@ -379,6 +384,7 @@ def parse_hook_filename(filename: str) -> tuple[str, int, bool] | None:
 
 
 def _plugin_runtime_enabled(config: PluginConfig, runtime: str | None = None) -> bool:
+    """Apply an optional, generic host-runtime allowlist from the manifest."""
     allowed_runtimes = {str(item).strip().lower() for item in config.x_runtimes if str(item).strip()}
     if not allowed_runtimes:
         return True
@@ -406,7 +412,8 @@ def load_plugin(plugin_dir: Path, *, runtime: str | None = None) -> Plugin | Non
     # Load config schema
     config_file = plugin_dir / "config.json"
     if config_file.exists():
-        plugin.config = PluginConfig.model_validate_json(config_file.read_text())
+        plugin.manifest = json.loads(config_file.read_text())
+        plugin.config = PluginConfig.model_validate(plugin.manifest)
         if not _plugin_runtime_enabled(plugin.config, runtime=runtime):
             return None
 
@@ -527,7 +534,7 @@ def filter_plugins(
     disabled = {n.lower() for n in disabled_names or []}
     explicit_names = names is not None
     if not names:
-        names = [name for name in plugins if name.lower() not in disabled]
+        names = [name for name, plugin in plugins.items() if plugin.config.x_auto_run and name.lower() not in disabled]
     else:
         names = [name for name in names if name.lower() not in disabled]
     if not names:

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -366,20 +366,19 @@ PLUGINS_DIR = _default_plugins_dir()
 def parse_hook_filename(filename: str) -> tuple[str, int, bool] | None:
     """Parse a hook filename to extract (event_type, order, is_background).
 
-    Format: `on_{Event}__[{order}_]{description}[.bg].{ext}`. The legacy
-    `__background` marker remains supported for existing user plugins.
+    Format: `on_{Event}__[{order}_]{description}[.bg].{ext}`.
 
     Returns None if the filename doesn't match the hook convention.
     Never attempt to determine .finite/.daemon/interpreter, hooks should be treated like black-box executables.
     """
     pattern = r"^on_(\w+)__(?:(\d+)_)?(.+)$"
-    match = re.match(pattern, filename.replace("__background", ""))
+    match = re.match(pattern, filename)
     if not match:
         return None
 
     event = match.group(1)
     order = int(match.group(2) or 0)
-    is_background = ".bg." in filename or "__background" in Path(filename).stem
+    is_background = ".bg." in filename
 
     return (event, order, is_background)
 

--- a/abx_dl/orchestrator.py
+++ b/abx_dl/orchestrator.py
@@ -80,6 +80,7 @@ import os
 import sys
 from collections.abc import Sequence
 from contextlib import nullcontext
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -88,6 +89,7 @@ from abxbus import EventBus, EventBusMiddleware, EventConcurrencyMode, EventHand
 from abxpkg.binary_service import BinaryRequestEvent, BinaryService
 
 from .config import GlobalConfig, RuntimeConfig, ensure_default_persona_dir, get_explicit_user_env, get_initial_env
+from .catalog import PluginCatalog
 from .events import (
     CrawlEvent,
     InstallEvent,
@@ -121,6 +123,7 @@ def setup_services(
     crawl_setup_enabled: bool = True,
     crawl_start_enabled: bool = True,
     snapshot_cleanup_enabled: bool = True,
+    emit_discovered_snapshot_events: bool = True,
     crawl_cleanup_enabled: bool = True,
     crawl_completed_enabled: bool = True,
     crawl_event_enabled: bool = True,
@@ -260,6 +263,7 @@ def setup_services(
                 snapshot_cleanup_enabled=snapshot_cleanup_enabled,
                 snapshot_cleanup_phase_timeout=snapshot_cleanup_phase_timeout,
                 abort_requested=abort_requested,
+                emit_discovered_snapshot_events=emit_discovered_snapshot_events,
             )
 
 
@@ -456,6 +460,125 @@ def compute_phase_timeout(hooks: list[tuple[Plugin, Hook]], config: dict[str, An
     return max(float(total), 60.0)
 
 
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """Framework-neutral description of one configured plugin execution.
+
+    Embedders own persistence and scheduling.  The plan owns the shared plugin
+    selection, config seed, and timeout calculations required to attach abx-dl
+    services to their EventBus.
+    """
+
+    plugins: dict[str, Plugin]
+    config: dict[str, Any]
+    derived_config: dict[str, Any]
+    runtime: str
+    install_timeout: float
+    crawl_setup_timeout: float
+    snapshot_timeout: float
+    crawl_cleanup_timeout: float
+
+    @classmethod
+    def build(
+        cls,
+        plugins: dict[str, Plugin] | PluginCatalog,
+        *,
+        selected_plugins: list[str] | None = None,
+        config: dict[str, Any] | None = None,
+        derived_config: dict[str, Any] | None = None,
+        runtime: str = "abx-dl",
+    ) -> ExecutionPlan:
+        catalog = plugins if isinstance(plugins, PluginCatalog) else PluginCatalog(dict(plugins))
+        selected = catalog.select(selected_plugins).plugins
+        runtime_config = dict(config or {})
+        runtime_config["ABX_RUNTIME"] = runtime
+        crawl_setup_hooks = [(plugin, hook) for plugin in selected.values() for hook in plugin.filter_hooks("CrawlSetup")]
+        snapshot_hooks = [(plugin, hook) for plugin in selected.values() for hook in plugin.filter_hooks("Snapshot")]
+        return cls(
+            plugins=selected,
+            config=runtime_config,
+            derived_config=dict(derived_config or {}),
+            runtime=runtime,
+            install_timeout=compute_install_phase_timeout(get_install_plugins(selected), runtime_config),
+            crawl_setup_timeout=compute_phase_timeout(crawl_setup_hooks, runtime_config),
+            snapshot_timeout=compute_phase_timeout(snapshot_hooks, runtime_config),
+            crawl_cleanup_timeout=compute_phase_timeout(crawl_setup_hooks, runtime_config),
+        )
+
+    @property
+    def runtime_config(self) -> RuntimeConfig:
+        return RuntimeConfig(
+            user=GlobalConfig(**self.config),
+            derived=dict(self.derived_config),
+        )
+
+    async def seed_config(self, bus: EventBus, *, parent_event: Any | None = None) -> None:
+        """Publish the plan's config layers through the normal runtime contract."""
+        user_event = MachineEvent(config=dict(self.config), config_type="user")
+        if parent_event is not None:
+            user_event.event_parent_id = parent_event.event_id
+        await bus.emit(user_event).now()
+        if self.derived_config:
+            derived_event = MachineEvent(config=dict(self.derived_config), config_type="derived")
+            if parent_event is not None:
+                derived_event.event_parent_id = parent_event.event_id
+            await bus.emit(derived_event).now()
+
+    def attach_services(
+        self,
+        bus: EventBus,
+        *,
+        url: str | None = None,
+        snapshot: Snapshot | None = None,
+        output_dir: Path | None = None,
+        **service_options: Any,
+    ) -> None:
+        """Attach shared services using this plan's single selected/configured view."""
+        setup_services(
+            bus,
+            plugins=self.plugins,
+            url=url,
+            snapshot=snapshot,
+            output_dir=output_dir,
+            runtime_config=self.runtime_config,
+            crawl_setup_phase_timeout=self.crawl_setup_timeout,
+            snapshot_phase_timeout=self.snapshot_timeout,
+            snapshot_cleanup_phase_timeout=self.snapshot_timeout,
+            crawl_cleanup_phase_timeout=self.crawl_cleanup_timeout,
+            **service_options,
+        )
+
+    def attach_snapshot_service(
+        self,
+        bus: EventBus,
+        *,
+        url: str,
+        snapshot: Snapshot,
+        output_dir: Path,
+        snapshot_service: type[SnapshotService] = SnapshotService,
+        timeout_padding: float = 0.0,
+        abort_requested: Any | None = None,
+        selected_hooks_by_plugin: dict[str, set[str] | None] | None = None,
+        emit_discovered_snapshot_events: bool = True,
+    ) -> SnapshotService:
+        """Attach one snapshot executor to an existing application-owned bus."""
+        timeout = self.snapshot_timeout + timeout_padding
+        return snapshot_service(
+            bus,
+            url=url,
+            snapshot=snapshot,
+            output_dir=output_dir,
+            plugins=self.plugins,
+            config=self.runtime_config,
+            snapshot_phase_timeout=timeout,
+            snapshot_cleanup_enabled=True,
+            snapshot_cleanup_phase_timeout=timeout,
+            abort_requested=abort_requested,
+            selected_hooks_by_plugin=selected_hooks_by_plugin,
+            emit_discovered_snapshot_events=emit_discovered_snapshot_events,
+        )
+
+
 def create_bus(
     *,
     total_timeout: float = 60.0,
@@ -587,8 +710,14 @@ async def download(
     if interactive_tty is None:
         interactive_tty = stdout_is_tty or sys.stderr.isatty()
 
-    # Filter plugins for runtime phases; binary providers are handled by abxpkg.
-    plugins = filter_plugins(plugins, selected_plugins)
+    plan = ExecutionPlan.build(
+        plugins,
+        selected_plugins=selected_plugins,
+        config=explicit_user_config,
+        derived_config=initial_derived_config,
+        runtime="abx-dl",
+    )
+    plugins = plan.plugins
 
     # Create snapshot record and write it as the first line of index.jsonl
     snapshot_payload: dict[str, Any] = {"url": url}
@@ -607,24 +736,11 @@ async def download(
     snapshot = Snapshot(**snapshot_payload)
     write_jsonl(index_path, snapshot, also_print=emit_jsonl)
 
-    # Collect and sort hooks by (order, name) so execution order matches
-    # the numeric prefix in hook filenames (e.g. __10, __41, __70, __90, __91)
-    crawl_setup_hooks: list[tuple[Plugin, Hook]] = []
-    snapshot_hooks: list[tuple[Plugin, Hook]] = []
-    for plugin in plugins.values():
-        for hook in plugin.filter_hooks("CrawlSetup"):
-            crawl_setup_hooks.append((plugin, hook))
-        for hook in plugin.filter_hooks("Snapshot"):
-            snapshot_hooks.append((plugin, hook))
-    crawl_setup_hooks.sort(key=lambda x: x[1].sort_key)
-    snapshot_hooks.sort(key=lambda x: x[1].sort_key)
-
-    # Compute per-phase timeouts from plugin-specific settings
-    install_phase_timeout = compute_install_phase_timeout(get_install_plugins(plugins), config_overrides or None)
-    crawl_setup_phase_timeout = compute_phase_timeout(crawl_setup_hooks, config_overrides or None)
-    snapshot_phase_timeout = compute_phase_timeout(snapshot_hooks, config_overrides or None)
+    install_phase_timeout = plan.install_timeout
+    crawl_setup_phase_timeout = plan.crawl_setup_timeout
+    snapshot_phase_timeout = plan.snapshot_timeout
     snapshot_cleanup_phase_timeout = snapshot_phase_timeout
-    crawl_cleanup_phase_timeout = crawl_setup_phase_timeout
+    crawl_cleanup_phase_timeout = plan.crawl_cleanup_timeout
     total_timeout = (
         install_phase_timeout
         + (crawl_setup_phase_timeout if crawl_setup_enabled else 0.0)
@@ -644,14 +760,7 @@ async def download(
         url=url,
         snapshot=snapshot,
         output_dir=output_dir,
-        runtime_config=RuntimeConfig(
-            # Preserve which values the user actually supplied. Passing the
-            # default-filled bootstrap mapping here marks every global default
-            # as explicit, causing TIMEOUT=60 to override plugin-specific
-            # defaults such as CLAUDECODECLEANUP_TIMEOUT=180.
-            user=GlobalConfig(**explicit_user_config),
-            derived=initial_derived_config,
-        ),
+        runtime_config=plan.runtime_config,
         install_enabled=True,
         crawl_setup_enabled=crawl_setup_enabled,
         crawl_start_enabled=crawl_start_enabled,
@@ -675,19 +784,7 @@ async def download(
         CrawlService=CrawlService,
         SnapshotService=SnapshotService,
     )
-    await bus.emit(
-        MachineEvent(
-            config=explicit_user_config,
-            config_type="user",
-        ),
-    ).now()
-    if initial_derived_config:
-        await bus.emit(
-            MachineEvent(
-                config=initial_derived_config,
-                config_type="derived",
-            ),
-        ).now()
+    await plan.seed_config(bus)
 
     heartbeat = None
     if crawl_setup_enabled or crawl_start_enabled or crawl_cleanup_enabled:

--- a/abx_dl/output_files.py
+++ b/abx_dl/output_files.py
@@ -6,9 +6,11 @@ import mimetypes
 import os
 import stat
 from pathlib import Path
-from collections.abc import Iterable
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 for strict in (True, False):
@@ -24,10 +26,81 @@ BROKEN_SYMLINK_SUFFIX = ".broken-symlink.txt"
 class OutputFile(BaseModel):
     """Metadata for a file emitted by a hook."""
 
+    model_config = ConfigDict(extra="allow")
+
     path: str
     extension: str = ""
     mimetype: str = ""
     size: int = 0
+
+
+class OutputManifest(BaseModel):
+    """Canonical normalized metadata for one hook output directory."""
+
+    files: list[OutputFile] = Field(default_factory=list)
+    total_size: int = 0
+    mimetypes: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_files(cls, files: Iterable[OutputFile | Mapping[str, Any]]) -> OutputManifest:
+        normalized = [item if isinstance(item, OutputFile) else OutputFile.model_validate(item) for item in files]
+        normalized.sort(key=lambda item: item.path)
+        mime_sizes: dict[str, int] = defaultdict(int)
+        total_size = 0
+        for output_file in normalized:
+            size = max(int(output_file.size or 0), 0)
+            total_size += size
+            if output_file.mimetype:
+                mime_sizes[output_file.mimetype] += size
+        mimetypes = [name for name, _size in sorted(mime_sizes.items(), key=lambda item: (-item[1], item[0]))]
+        return cls(files=normalized, total_size=total_size, mimetypes=mimetypes)
+
+    @classmethod
+    def from_value(cls, value: Any) -> OutputManifest:
+        if value is None:
+            return cls()
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            import json
+
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                return cls()
+        if isinstance(value, Mapping):
+            files = []
+            for path, metadata in value.items():
+                payload = dict(metadata) if isinstance(metadata, Mapping) else {}
+                payload["path"] = str(path)
+                payload.setdefault("extension", Path(str(path)).suffix.lower().lstrip("."))
+                payload.setdefault("mimetype", guess_mimetype(str(path)))
+                files.append(payload)
+            return cls.from_files(files)
+        if isinstance(value, Iterable):
+            files = []
+            for item in value:
+                if isinstance(item, str):
+                    files.append({"path": item, "extension": Path(item).suffix.lower().lstrip("."), "mimetype": guess_mimetype(item)})
+                elif isinstance(item, OutputFile):
+                    files.append(item)
+                elif isinstance(item, Mapping) and item.get("path"):
+                    files.append(item)
+            return cls.from_files(files)
+        return cls()
+
+    @classmethod
+    def scan(
+        cls,
+        output_dir: Path,
+        file_paths: Iterable[Path] | None = None,
+        *,
+        containment_root: Path | None = None,
+    ) -> OutputManifest:
+        return cls.from_files(scan_output_files(output_dir, file_paths, containment_root=containment_root))
+
+    def as_mapping(self) -> dict[str, dict[str, Any]]:
+        return {output_file.path: output_file.model_dump(exclude={"path"}) for output_file in self.files}
 
 
 def guess_mimetype(path: str | Path) -> str:
@@ -94,6 +167,8 @@ def scan_output_files(
             _neutralize_escaping_symlink(file_path, containment_root)
             continue
         if not stat.S_ISREG(stat_result.st_mode):
+            continue
+        if ".hooks" in file_path.relative_to(output_dir).parts:
             continue
         if stat_result.st_mode & EXECUTABLE_BITS:
             try:

--- a/abx_dl/services/process_service.py
+++ b/abx_dl/services/process_service.py
@@ -874,8 +874,6 @@ class ProcessService(BaseService):
         for line in lines:
             state.stdout_lines.append(line)
             stripped = line.strip()
-            if event.env.get("ABX_RUNTIME", "").lower() == "archivebox" and '"type": "Snapshot"' in stripped:
-                continue
             try:
                 await event.emit(
                     ProcessStdoutEvent(

--- a/abx_dl/services/snapshot_service.py
+++ b/abx_dl/services/snapshot_service.py
@@ -121,6 +121,7 @@ class SnapshotService(BaseService):
         snapshot_cleanup_phase_timeout: float = 300.0,
         abort_requested: Callable[[], bool | Awaitable[bool]] | None = None,
         selected_hooks_by_plugin: dict[str, set[str] | None] | None = None,
+        emit_discovered_snapshot_events: bool = True,
     ):
         self.url = url
         self.snapshot = snapshot
@@ -145,6 +146,7 @@ class SnapshotService(BaseService):
         self.snapshot_cleanup_phase_timeout = snapshot_cleanup_phase_timeout
         self.abort_requested = False
         self.abort_requested_callback = abort_requested
+        self.emit_discovered_snapshot_events = emit_discovered_snapshot_events
         self.limit_state: CrawlLimitState | None = None
         self.config: RuntimeConfig = config
         self._hook_timeouts: dict[tuple[str, str], int] = {}
@@ -340,7 +342,7 @@ class SnapshotService(BaseService):
         """
         if Path(event.output_dir).parent != self.output_dir:
             return
-        if str(self.config.user.ABX_RUNTIME).lower() == "archivebox":
+        if not self.emit_discovered_snapshot_events:
             return
         try:
             record = json.loads(event.line)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -26,9 +26,10 @@ from abx_dl.events import (
     SnapshotCompletedEvent,
     SnapshotEvent,
 )
+from abx_dl.execution import build_hook_args, execute_hook
 from abx_dl.limits import CrawlLimitState
-from abx_dl.models import Snapshot, discover_plugins, filter_plugins
-from abx_dl.orchestrator import create_bus, download, setup_services
+from abx_dl.models import Hook, Snapshot, discover_plugins, filter_plugins
+from abx_dl.orchestrator import ExecutionPlan, create_bus, download, setup_services
 from abx_dl.services.archive_result_service import ArchiveResultService
 from abx_dl.services.binary_service import PluginBinaryEnvService
 from abx_dl.services.crawl_service import CrawlService
@@ -37,6 +38,40 @@ from abx_dl.services.snapshot_service import SnapshotService
 from abxpkg.binary_service import BinaryEvent, BinaryRequestEvent, BinaryService
 from pytest_httpserver import HTTPServer
 from werkzeug import Response
+
+
+def test_build_hook_args_uses_standalone_cli_contract():
+    assert build_hook_args({"url": "https://example.com", "depth": 2, "enabled": True, "skip": False}) == [
+        "--url=https://example.com",
+        "--depth=2",
+        "--enabled",
+    ]
+
+
+def test_execute_hook_runs_without_application_framework(tmp_path):
+    script = tmp_path / "on_Snapshot__10_example.py"
+    script.write_text('#!/bin/sh\nprintf \'{"type":"ArchiveResult","status":"succeeded"}\\n\'\n')
+    script.chmod(0o755)
+    hook = Hook(
+        name=script.name,
+        event="SnapshotEvent",
+        plugin_name="example",
+        path=script,
+        order=10,
+        is_background=False,
+    )
+
+    completed = asyncio.run(
+        execute_hook(
+            hook,
+            output_dir=tmp_path / "output",
+            env={"PATH": os.environ["PATH"]},
+            arguments={"url": "https://example.com"},
+        ),
+    )
+
+    assert completed.exit_code == 0
+    assert '"status":"succeeded"' in completed.stdout
 
 
 def _binary_extra_context(
@@ -496,6 +531,37 @@ def test_setup_services_accepts_runtime_config_overrides_and_seeds_machine_event
     assert user_event.config["TIMEOUT"] == 123
     assert user_event.config["DRY_RUN"] is True
     assert derived_event.config == {"WGET_BINARY": str(wget_binary.abspath)}
+
+
+def test_execution_plan_centralizes_selection_timeouts_and_runtime_config(tmp_path: Path) -> None:
+    plan = ExecutionPlan.build(
+        discover_plugins(runtime="archivebox"),
+        selected_plugins=["title", "wget"],
+        config={"TIMEOUT": 17},
+        derived_config={"WGET_BINARY": str(tmp_path / "wget")},
+        runtime="archivebox",
+    )
+
+    assert {"chrome", "title", "wget"} <= set(plan.plugins)
+    assert plan.runtime_config.user.ABX_RUNTIME == "archivebox"
+    assert plan.runtime_config.user.TIMEOUT == 17
+    assert plan.runtime_config.derived == {"WGET_BINARY": str(tmp_path / "wget")}
+    assert plan.snapshot_timeout >= 60.0
+
+    async def run() -> list[MachineEvent]:
+        bus = create_bus(total_timeout=5.0, name=f"execution_plan_{uuid4().hex[:8]}")
+        observed: list[MachineEvent] = []
+
+        async def on_MachineEvent(event: MachineEvent) -> None:
+            observed.append(event)
+
+        bus.on(MachineEvent, on_MachineEvent)
+        await plan.seed_config(bus)
+        await bus.wait_until_idle()
+        return observed
+
+    events = asyncio.run(run())
+    assert [event.config_type for event in events] == ["user", "derived"]
 
 
 def test_binary_service_stops_after_successful_provider_result(tmp_path: Path) -> None:

--- a/tests/test_output_files.py
+++ b/tests/test_output_files.py
@@ -4,7 +4,7 @@ import stat
 from pathlib import Path
 
 from abx_dl.models import discover_plugins
-from abx_dl.output_files import scan_output_files
+from abx_dl.output_files import OutputManifest, scan_output_files
 
 
 def test_scan_output_files_excludes_symlinked_files_and_dirs(tmp_path: Path) -> None:
@@ -99,3 +99,15 @@ def test_scan_output_files_symlink_neutralization_is_idempotent(tmp_path: Path) 
     assert record.is_file() and not record.is_symlink()
     assert record.read_text().strip() == str(outside)
     assert not (snap_dir / "leak").exists()
+
+
+def test_output_manifest_is_the_canonical_mapping_and_summary(tmp_path: Path) -> None:
+    (tmp_path / "page.html").write_text("<h1>Hello</h1>")
+    (tmp_path / "data.json").write_text('{"ok": true}')
+
+    manifest = OutputManifest.scan(tmp_path)
+
+    assert list(manifest.as_mapping()) == ["data.json", "page.html"]
+    assert manifest.total_size == len("<h1>Hello</h1>") + len('{"ok": true}')
+    assert manifest.mimetypes[0] in {"application/json", "text/html"}
+    assert OutputManifest.from_value(manifest.as_mapping()) == manifest

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -12,7 +12,6 @@ from abx_dl.models import discover_plugins, filter_plugins, parse_hook_filename
 
 def test_parse_hook_filename_marks_bg_hooks() -> None:
     assert parse_hook_filename("on_Snapshot__66_papersdl.finite.bg.py") == ("Snapshot", 66, True)
-    assert parse_hook_filename("on_Snapshot__66_papersdl__background.py") == ("Snapshot", 66, True)
     assert parse_hook_filename("on_Snapshot__9_chrome_wait.js") == ("Snapshot", 9, False)
     assert parse_hook_filename("on_Snapshot__chrome_wait.js") == ("Snapshot", 0, False)
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from abx_dl.catalog import PluginCatalog, PluginConfigResolver
 from abx_dl.config import get_initial_env, get_required_binary_requests
 from abx_dl.models import discover_plugins, filter_plugins, parse_hook_filename
 
@@ -66,6 +67,56 @@ def test_discover_plugins_extends_packaged_plugins_with_runtime_plugin_dir(tmp_p
     assert "wget" in discovered_hooks
     assert "parse_html_urls" in discovered_hooks
     assert discovered_hooks["runtime_only"] == [title_hook.name]
+
+
+def test_plugin_catalog_exposes_complete_metadata_and_sorted_hooks() -> None:
+    catalog = PluginCatalog.discover(runtime="archivebox")
+
+    assert "wget" in catalog
+    assert catalog["wget"].manifest["properties"]["WGET_ENABLED"]["type"] == "boolean"
+    assert catalog.schemas["wget"]["title"] == catalog["wget"].config.title
+    hooks = catalog.hooks("Snapshot", names=["title", "wget"])
+    assert hooks == sorted(hooks, key=lambda item: item[1].sort_key)
+    assert {plugin.name for plugin, _hook in hooks} == {"chrome", "title", "wget"}
+
+
+def test_plugin_catalog_extra_dirs_override_packaged_plugins(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "wget"
+    plugin_dir.mkdir()
+    (plugin_dir / "config.json").write_text('{"title":"Custom Wget","properties":{}}')
+
+    catalog = PluginCatalog.discover(extra_plugin_dirs=[tmp_path])
+
+    assert catalog["wget"].path == plugin_dir
+    assert catalog["wget"].manifest["title"] == "Custom Wget"
+
+
+def test_default_selection_excludes_plugins_that_require_explicit_selection(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "explicit"
+    plugin_dir.mkdir()
+    (plugin_dir / "config.json").write_text('{"title":"Explicit","x-auto-run":false,"properties":{}}')
+    catalog = PluginCatalog.discover(plugins_dir=tmp_path)
+
+    assert "explicit" not in catalog.select()
+    assert "explicit" in catalog.select(["explicit"])
+
+
+def test_plugin_config_resolver_uses_manifest_aliases_and_dependencies() -> None:
+    resolver = PluginConfigResolver(PluginCatalog.discover(runtime="archivebox"))
+
+    resolved = resolver.resolve(user_config={"SAVE_WGET": "False", "UBLOCK_ENABLED": "True"}, environ={})
+    enabled = resolver.enabled_plugin_names(resolved=resolved)
+
+    assert resolver.canonical_key("SAVE_WGET") == "WGET_ENABLED"
+    assert "wget" not in enabled
+    assert "ublock" in enabled
+    assert "chrome" in enabled
+    assert "wget" not in resolver.enabled_plugin_names_from_flat({"WGET_ENABLED": False})
+    assert resolver.runtime_settings("wget", {"TIMEOUT": 91, "WGET_BINARY": "/bin/wget"}) == {
+        "enabled": True,
+        "timeout": 91,
+        "binary": "/bin/wget",
+    }
 
 
 def test_filter_plugins_does_not_add_binary_providers_for_wget() -> None:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -12,6 +12,7 @@ from abx_dl.models import discover_plugins, filter_plugins, parse_hook_filename
 
 def test_parse_hook_filename_marks_bg_hooks() -> None:
     assert parse_hook_filename("on_Snapshot__66_papersdl.finite.bg.py") == ("Snapshot", 66, True)
+    assert parse_hook_filename("on_Snapshot__66_papersdl__background.py") == ("Snapshot", 66, True)
     assert parse_hook_filename("on_Snapshot__9_chrome_wait.js") == ("Snapshot", 9, False)
     assert parse_hook_filename("on_Snapshot__chrome_wait.js") == ("Snapshot", 0, False)
 


### PR DESCRIPTION
## Summary

- add one PluginCatalog for manifests, hooks, custom plugin directories, and presentation metadata
- add one PluginConfigResolver for aliases, config precedence, enabled selection, and conventional runtime settings
- add ExecutionPlan and execute_hook embedding APIs around the existing event runtime
- add OutputManifest as the canonical output metadata representation
- replace host-name special cases with generic runtime and discovered-event options

## Boundary

The abx_dl package contains no ArchiveBox or Django imports or product literals. Embedders provide plain mappings, paths, environment variables, CLI arguments, and an optional event bus; they retain ownership of persistence and scheduling.

The old generic x-runtimes manifest allowlist remains readable for release-order compatibility, while x-auto-run is the new product-neutral explicit-selection control.

## Coordinated cleanup and promotion order

- ArchiveBox/abx-plugins#59 provides the generic manifest metadata
- ArchiveBox/ArchiveBox#1850 is the host-side integration

This PR remains draft until abx-plugins#59 merges and releases. Then this same branch must advance its exact abx-plugins pin and lockfile to that release before becoming ready. After this PR releases, ArchiveBox#1850 advances both exact package pins and runs its native CI without any temporary shim or git dependency.

## Validation

- prek run --all-files
- full suite: 177 passed, 1 skipped; the single transient README codeblock failure passed immediately when rerun
- focused runtime/catalog/output tests: 72 passed
- nested/discovered snapshot tests: 2 passed