### PR TITLE
refactor: simplify snapshot orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,22 @@ Plugins are loaded from the installed [`abx-plugins`](https://pypi.org/project/a
 
 Applications embedding the runtime use the same framework-free interfaces as
 the CLI: `PluginCatalog` for inventory, `PluginConfigResolver` for config,
-`ExecutionPlan` for plugin selection/service setup, `execute_hook()` for a
-single finite hook, and `OutputManifest` for output metadata. These APIs accept
-plain mappings, filesystem paths, environment variables, and CLI arguments;
-they do not depend on Django or an application database.
+the service classes for explicit listener composition, typed events for phase
+dispatch, `execute_hook()` for a single finite hook, and `OutputManifest` for
+output metadata. These APIs accept plain mappings, filesystem paths,
+environment variables, and CLI arguments; they do not depend on Django or an
+application database.
+
+Standalone `download()` attaches both `CrawlService` (plugin crawl hooks) and
+`CrawlLifecycleService` (phase sequencing). Embedders can attach only the
+listener suites whose behavior they want and dispatch the corresponding typed
+events directly.
+
+`parse_input(source_text, catalog, output_dir)` is the framework-free import
+path for pasted text and bookmark/feed exports. It writes
+`staticfile/stdin.txt`, runs only plugins declaring
+`x-accepts-internal-input`, and returns metadata-preserving `Snapshot` facts at
+depth zero. It does not create a crawl, database row, or synthetic URL.
 
 
 <br/>

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -63,7 +63,7 @@ from .models import (
     Process,
     now_iso,
 )
-from .orchestrator import ExecutionPlan, create_bus, download, get_install_plugins, install_plugins
+from .orchestrator import compute_install_phase_timeout, compute_phase_timeout, create_bus, download, get_install_plugins, install_plugins
 from .output_files import OutputFile
 from .tables import binary_dependency_status, binary_dependency_table
 
@@ -1408,15 +1408,16 @@ def dl(
     ui_console = stderr_console if stderr_is_tty or not stdout_is_tty else console
 
     disabled = [plugin.strip() for plugin in disable_list.split(",") if plugin.strip()] if disable_list else []
-    plan = ExecutionPlan.build(
-        catalog,
-        selected_plugins=selected,
-        disabled_plugins=disabled,
-        config={**get_explicit_user_env(), **config_overrides},
+    selected_catalog = catalog.select(selected, disabled_names=disabled)
+    user_config = {**get_explicit_user_env(), **config_overrides, "ABX_RUNTIME": "abx-dl"}
+    install_timeout = compute_install_phase_timeout(get_install_plugins(selected_catalog), user_config)
+    crawl_setup_timeout = compute_phase_timeout(selected_catalog.hooks("CrawlSetup"), user_config)
+    snapshot_timeout = compute_phase_timeout(selected_catalog.hooks("Snapshot"), user_config)
+    selected = list(selected_catalog)
+    total_timeout = install_timeout + crawl_setup_timeout + snapshot_timeout
+    total_hooks = (
+        _count_install_requests(selected_catalog) + len(selected_catalog.hooks("CrawlSetup")) + len(selected_catalog.hooks("Snapshot"))
     )
-    selected = list(plan.catalog)
-    total_timeout = plan.install_timeout + plan.crawl_setup_timeout + plan.snapshot_timeout
-    total_hooks = _count_install_requests(plan.catalog) + len(plan.catalog.hooks("CrawlSetup")) + len(plan.catalog.hooks("Snapshot"))
     bus = create_bus(total_timeout=total_timeout)
     live_ui = LiveBusUI(
         bus,
@@ -1475,9 +1476,10 @@ def dl(
             download_task = loop.create_task(
                 download(
                     url,
-                    plan,
+                    selected_catalog,
                     out_path,
                     auto_install=not no_install,
+                    config=user_config,
                     emit_jsonl=not stdout_is_tty,
                     interactive_tty=interactive_tty,
                     bus=bus,
@@ -1624,12 +1626,9 @@ def _run_plugin_install(
     selected_plugin_config = {plugin.enabled_key: True for plugin in selected.values() if plugin.enabled_key in plugin.config.properties}
     if dry_run:
         selected_plugin_config["DRY_RUN"] = True
-    plan = ExecutionPlan.build(
-        selected,
-        selected_plugins=list(selected),
-        config={**get_explicit_user_env(), **selected_plugin_config},
-    )
-    bus = create_bus(total_timeout=plan.install_timeout)
+    user_config = {**get_explicit_user_env(), **selected_plugin_config, "ABX_RUNTIME": "abx-dl"}
+    install_timeout = compute_install_phase_timeout(get_install_plugins(selected), user_config)
+    bus = create_bus(total_timeout=install_timeout)
     live = None
 
     async def on_BinaryRequestEvent(event: BinaryRequestEvent) -> None:
@@ -1690,7 +1689,8 @@ def _run_plugin_install(
                     debug=debug,
                     func=lambda: loop.run_until_complete(
                         install_plugins(
-                            plan,
+                            selected,
+                            config=user_config,
                             output_dir=Path(temp_dir),
                             emit_jsonl=False,
                             bus=bus,

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -63,7 +63,15 @@ from .models import (
     Process,
     now_iso,
 )
-from .orchestrator import compute_install_phase_timeout, compute_phase_timeout, create_bus, download, get_install_plugins, install_plugins
+from .orchestrator import (
+    compute_install_phase_timeout,
+    compute_phase_timeout,
+    create_bus,
+    download,
+    get_install_plugins,
+    get_phase_hooks,
+    install_plugins,
+)
 from .output_files import OutputFile
 from .tables import binary_dependency_status, binary_dependency_table
 
@@ -1411,8 +1419,8 @@ def dl(
     selected_catalog = catalog.select(selected, disabled_names=disabled)
     user_config = {**get_explicit_user_env(), **config_overrides, "ABX_RUNTIME": "abx-dl"}
     install_timeout = compute_install_phase_timeout(get_install_plugins(selected_catalog), user_config)
-    crawl_setup_hooks = [(plugin, hook) for plugin in selected_catalog.values() for hook in plugin.filter_hooks("CrawlSetup")]
-    snapshot_hooks = [(plugin, hook) for plugin in selected_catalog.values() for hook in plugin.filter_hooks("Snapshot")]
+    crawl_setup_hooks = get_phase_hooks(selected_catalog, "CrawlSetup")
+    snapshot_hooks = get_phase_hooks(selected_catalog, "Snapshot")
     crawl_setup_timeout = compute_phase_timeout(crawl_setup_hooks, user_config)
     snapshot_timeout = compute_phase_timeout(snapshot_hooks, user_config)
     selected = list(selected_catalog)

--- a/abx_dl/cli.py
+++ b/abx_dl/cli.py
@@ -1411,13 +1411,13 @@ def dl(
     selected_catalog = catalog.select(selected, disabled_names=disabled)
     user_config = {**get_explicit_user_env(), **config_overrides, "ABX_RUNTIME": "abx-dl"}
     install_timeout = compute_install_phase_timeout(get_install_plugins(selected_catalog), user_config)
-    crawl_setup_timeout = compute_phase_timeout(selected_catalog.hooks("CrawlSetup"), user_config)
-    snapshot_timeout = compute_phase_timeout(selected_catalog.hooks("Snapshot"), user_config)
+    crawl_setup_hooks = [(plugin, hook) for plugin in selected_catalog.values() for hook in plugin.filter_hooks("CrawlSetup")]
+    snapshot_hooks = [(plugin, hook) for plugin in selected_catalog.values() for hook in plugin.filter_hooks("Snapshot")]
+    crawl_setup_timeout = compute_phase_timeout(crawl_setup_hooks, user_config)
+    snapshot_timeout = compute_phase_timeout(snapshot_hooks, user_config)
     selected = list(selected_catalog)
     total_timeout = install_timeout + crawl_setup_timeout + snapshot_timeout
-    total_hooks = (
-        _count_install_requests(selected_catalog) + len(selected_catalog.hooks("CrawlSetup")) + len(selected_catalog.hooks("Snapshot"))
-    )
+    total_hooks = _count_install_requests(selected_catalog) + len(crawl_setup_hooks) + len(snapshot_hooks)
     bus = create_bus(total_timeout=total_timeout)
     live_ui = LiveBusUI(
         bus,

--- a/abx_dl/events.py
+++ b/abx_dl/events.py
@@ -10,7 +10,7 @@ Events form this phase order during execution::
     │   └── SnapshotEvent (depth=0)
     │       ├── ProcessEvent (on_Snapshot hooks)
     │       │   ├── ProcessStdoutEvent
-    │       │   │   ├── SnapshotEvent (depth>0, ignored by abx-dl)
+    │       │   │   ├── SnapshotDiscoveredEvent
     │       │   │   ├── TagEvent
     │       │   │   └── ArchiveResultEvent (inline)
     │       │   └── ProcessCompletedEvent
@@ -31,8 +31,8 @@ Event types:
   typed events used by the rest of the runtime
 - **Command events** trigger actions: ProcessEvent, ProcessKillEvent,
   BinaryRequestEvent, MachineEvent
-- **Completion events** notify results: ProcessCompletedEvent,
-  ArchiveResultEvent, BinaryEvent
+- **Fact/completion events** notify results: SnapshotDiscoveredEvent,
+  ProcessCompletedEvent, ArchiveResultEvent, BinaryEvent
 
 abxbus behavior:
 - Each event has ``event_timeout`` — the hard deadline for the event and all its
@@ -50,6 +50,7 @@ from typing import Any, Literal
 from abxbus import BaseEvent, EventConcurrencyMode, EventHandlerConcurrencyMode
 from pydantic import ConfigDict, Field
 
+from .models import Snapshot
 from .output_files import OutputFile
 
 
@@ -82,7 +83,7 @@ class InstallEvent(BaseEvent):
 class CrawlEvent(BaseEvent):
     """Root event: kicks off the full crawl → snapshot → cleanup lifecycle.
 
-    Emitted once by orchestrator.download(). CrawlService.on_CrawlEvent handles
+    Emitted once by orchestrator.download(). CrawlLifecycleService handles
     this by emitting the lifecycle chain:
     CrawlSetupEvent → CrawlStartEvent → CrawlCleanupEvent → CrawlCompletedEvent.
     """
@@ -96,7 +97,7 @@ class CrawlEvent(BaseEvent):
 class CrawlSetupEvent(BaseEvent):
     """Phase: run all on_CrawlSetup hooks (daemons and shared runtime setup).
 
-    Emitted by CrawlService.on_CrawlEvent. Per-hook handlers are registered
+    Emitted by CrawlLifecycleService. Per-hook handlers are registered
     on this event, so they run serially in hook sort order. Crawl setup hooks
     are expected to prepare shared state and emit no stdout JSONL records.
     """
@@ -112,9 +113,8 @@ class CrawlSetupEvent(BaseEvent):
 class CrawlStartEvent(BaseEvent):
     """Phase: crawl setup finished, start the actual crawl (snapshot extraction).
 
-    Emitted by CrawlService.on_CrawlEvent after CrawlSetupEvent completes.
-    CrawlService.on_CrawlStartEvent emits SnapshotEvent when snapshot
-    execution is enabled for the current run.
+    Emitted by CrawlLifecycleService after CrawlSetupEvent completes.
+    CrawlLifecycleService emits SnapshotEvent for standalone execution.
     """
 
     url: str
@@ -126,7 +126,7 @@ class CrawlStartEvent(BaseEvent):
 class CrawlCleanupEvent(BaseEvent):
     """Phase: SIGTERM all background crawl hooks.
 
-    Emitted by CrawlService.on_CrawlEvent after snapshot phase completes.
+    Emitted by CrawlLifecycleService after snapshot phase completes.
     """
 
     url: str
@@ -178,15 +178,12 @@ class CrawlResumeAndSkipEvent(BaseEvent):
 class SnapshotEvent(BaseEvent):
     """Phase: run all on_Snapshot hooks (extraction + discovery).
 
-    Emitted by CrawlService.on_CrawlStartEvent as a child of
+    Emitted by CrawlLifecycleService as a child of
     CrawlStartEvent. Per-hook handlers are registered on this event.
 
-    Also emitted by SnapshotService.on_ProcessStdoutEvent when a hook
-    outputs ``{"type": "Snapshot", ...}`` JSONL. Snapshot hooks emit
-    ``ArchiveResult`` records for their own result and may also emit
-    ``Snapshot`` and ``Tag`` discovery records. In abx-dl, SnapshotService
-    ignores events with ``depth > 0``. ArchiveBox handles recursive crawling
-    by processing all depths.
+    Hook-emitted ``{"type": "Snapshot", ...}`` JSONL records become
+    SnapshotDiscoveredEvent facts instead. Discovery cannot accidentally
+    execute another snapshot.
     """
 
     event_handler_concurrency: EventHandlerConcurrencyMode | None = EventHandlerConcurrencyMode.SERIAL
@@ -196,6 +193,21 @@ class SnapshotEvent(BaseEvent):
     output_dir: str
     depth: int = 0
     event_timeout: float | None = 300.0
+
+
+class SnapshotDiscoveredEvent(BaseEvent):
+    """Fact: a snapshot hook discovered a URL and its import metadata.
+
+    This is deliberately separate from ``SnapshotEvent``, which is a command
+    to execute snapshot hooks. Collection applications may persist these facts
+    or turn them into later work without discovery recursively executing work
+    inside abx-dl.
+    """
+
+    snapshot: Snapshot
+    plugin_name: str = ""
+    hook_name: str = ""
+    event_timeout: float | None = 10.0
 
 
 class SnapshotCleanupEvent(BaseEvent):
@@ -338,7 +350,7 @@ class ProcessStdoutEvent(BaseEvent):
     parses the line and checks for the JSON shape it cares about. In the
     current hook contract:
 
-    - snapshot hooks emit ``{"type": "Snapshot", ...}`` → SnapshotEvent
+    - snapshot hooks emit ``{"type": "Snapshot", ...}`` → SnapshotDiscoveredEvent
     - snapshot hooks emit ``{"type": "Tag", ...}`` → TagEvent
     - snapshot hooks emit ``{"type": "ArchiveResult", ...}`` → ArchiveResultEvent
 

--- a/abx_dl/models.py
+++ b/abx_dl/models.py
@@ -287,12 +287,19 @@ class Process(BaseModel):
 class Snapshot(BaseModel):
     """A URL being archived — one per download() call."""
 
-    model_config = ConfigDict(extra="ignore")
+    # Parser plugins attach import metadata such as title, tags, bookmarked_at,
+    # and the producing plugin. Keep it on discovery facts so embedders can
+    # persist the complete record without reparsing plugin output files.
+    model_config = ConfigDict(extra="allow")
 
     url: str
     id: str = Field(default_factory=uuid7)
     depth: int = 0
     crawl_id: str | None = None
+    title: str | None = None
+    tags: str | None = None
+    bookmarked_at: str | None = None
+    plugin: str | None = None
 
     def to_jsonl(self) -> str:
         d = {k: v for k, v in self.model_dump().items() if v is not None}

--- a/abx_dl/orchestrator.py
+++ b/abx_dl/orchestrator.py
@@ -21,7 +21,7 @@ Full event tree for a typical run::
     │   └── SnapshotEvent (depth=0)
     │       ├── ProcessEvent  (on_Snapshot hooks)
     │       │   ├── ProcessStdoutEvent
-    │       │   │   ├── SnapshotEvent (depth>0, ignored by abx-dl)
+    │       │   │   ├── SnapshotDiscoveredEvent
     │       │   │   ├── TagEvent
     │       │   │   └── ArchiveResultEvent (from hook JSONL)
     │       │   └── ProcessCompletedEvent
@@ -77,9 +77,8 @@ from __future__ import annotations
 import json
 import os
 import sys
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from contextlib import nullcontext
-from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -93,11 +92,14 @@ from .events import (
     CrawlEvent,
     InstallEvent,
     MachineEvent,
+    SnapshotDiscoveredEvent,
+    SnapshotEvent,
     slow_warning_timeout,
 )
 from .models import Hook, Plugin, RequiredBinary, Snapshot, write_jsonl
 from .services import (
     ArchiveResultService,
+    CrawlLifecycleService,
     CrawlService,
     PluginBinariesService,
     PluginBinaryEnvService,
@@ -105,128 +107,6 @@ from .services import (
     SnapshotService,
     TagService,
 )
-
-
-def _attach_services(
-    bus: EventBus,
-    *,
-    catalog: PluginCatalog,
-    url: str | None = None,
-    snapshot: Snapshot | None = None,
-    output_dir: Path | None = None,
-    runtime_config: RuntimeConfig,
-    install_enabled: bool = True,
-    crawl_setup_enabled: bool = True,
-    crawl_start_enabled: bool = True,
-    snapshot_cleanup_enabled: bool = True,
-    emit_discovered_snapshot_events: bool = True,
-    crawl_cleanup_enabled: bool = True,
-    crawl_completed_enabled: bool = True,
-    crawl_event_enabled: bool = True,
-    crawl_setup_phase_timeout: float = 300.0,
-    snapshot_phase_timeout: float = 300.0,
-    snapshot_cleanup_phase_timeout: float = 300.0,
-    crawl_cleanup_phase_timeout: float = 300.0,
-    auto_install: bool = True,
-    emit_jsonl: bool = True,
-    interactive_tty: bool | None = None,
-    abort_requested: Any | None = None,
-    PluginBinariesService: type[PluginBinariesService] | None = PluginBinariesService,
-    PluginBinaryEnvService: type[PluginBinaryEnvService] | None = PluginBinaryEnvService,
-    BinaryService: type[BinaryService] | None = BinaryService,
-    ProcessService: type[ProcessService] | None = ProcessService,
-    ArchiveResultService: type[ArchiveResultService] | None = ArchiveResultService,
-    TagService: type[TagService] | None = TagService,
-    CrawlService: type[CrawlService] | None = CrawlService,
-    SnapshotService: type[SnapshotService] | None = SnapshotService,
-) -> None:
-    """Attach the shared abx-dl services to an existing bus.
-
-    ExecutionPlan is the public entrypoint for attaching this configured view
-    to an application-owned event bus.
-    """
-    if interactive_tty is None:
-        interactive_tty = sys.stdout.isatty() or sys.stderr.isatty()
-
-    if PluginBinaryEnvService is not None:
-        PluginBinaryEnvService(bus, catalog=catalog)
-
-    if BinaryService is not None:
-        BinaryService(
-            bus,
-            auto_install=auto_install,
-        )
-
-    if install_enabled and PluginBinariesService is not None:
-        install_plugins = get_install_plugins(catalog)
-        PluginBinariesService(
-            bus,
-            catalog=catalog,
-            auto_install=auto_install,
-            install_plugins=install_plugins,
-            output_dir=output_dir,
-            snapshot=snapshot,
-            abort_requested=abort_requested,
-        )
-
-    if ProcessService is not None:
-        ProcessService(
-            bus,
-            emit_jsonl=emit_jsonl,
-            interactive_tty=bool(interactive_tty),
-        )
-
-    if ArchiveResultService is not None:
-        ArchiveResultService(
-            bus,
-            emit_jsonl=emit_jsonl,
-        )
-
-    if TagService is not None:
-        TagService(bus)
-
-    if (
-        CrawlService is not None
-        and url is not None
-        and snapshot is not None
-        and output_dir is not None
-        and (crawl_setup_enabled or crawl_start_enabled or crawl_cleanup_enabled)
-    ):
-        CrawlService(
-            bus,
-            url=url,
-            snapshot=snapshot,
-            output_dir=output_dir,
-            catalog=catalog,
-            crawl_setup_enabled=crawl_setup_enabled,
-            crawl_start_enabled=crawl_start_enabled,
-            crawl_cleanup_enabled=crawl_cleanup_enabled,
-            crawl_completed_enabled=crawl_completed_enabled,
-            crawl_event_enabled=crawl_event_enabled,
-            crawl_setup_phase_timeout=crawl_setup_phase_timeout,
-            snapshot_phase_timeout=snapshot_phase_timeout,
-            snapshot_cleanup_phase_timeout=snapshot_cleanup_phase_timeout,
-            crawl_cleanup_phase_timeout=crawl_cleanup_phase_timeout,
-            abort_requested=abort_requested,
-        )
-        if SnapshotService is not None and (crawl_start_enabled or snapshot_cleanup_enabled):
-            if runtime_config is None:
-                raise TypeError(
-                    "runtime_config is required when ExecutionPlan attaches SnapshotService",
-                )
-            SnapshotService(
-                bus,
-                url=url,
-                snapshot=snapshot,
-                output_dir=output_dir,
-                catalog=catalog,
-                config=runtime_config,
-                snapshot_phase_timeout=snapshot_phase_timeout,
-                snapshot_cleanup_enabled=snapshot_cleanup_enabled,
-                snapshot_cleanup_phase_timeout=snapshot_cleanup_phase_timeout,
-                abort_requested=abort_requested,
-                emit_discovered_snapshot_events=emit_discovered_snapshot_events,
-            )
 
 
 def get_install_plugins(catalog: PluginCatalog) -> list[Plugin]:
@@ -269,15 +149,14 @@ def compute_install_phase_timeout(plugins: list[Plugin], config: dict[str, Any] 
 
 
 async def install_plugins(
-    plan: ExecutionPlan,
+    catalog: PluginCatalog,
     *,
+    config: dict[str, Any] | None = None,
+    derived_config: dict[str, Any] | None = None,
+    runtime: str = "abx-dl",
     output_dir: Path | None = None,
     emit_jsonl: bool = False,
     bus: EventBus | None = None,
-    PluginBinariesService: type[PluginBinariesService] | None = PluginBinariesService,
-    PluginBinaryEnvService: type[PluginBinaryEnvService] | None = PluginBinaryEnvService,
-    BinaryService: type[BinaryService] | None = BinaryService,
-    ProcessService: type[ProcessService] | None = ProcessService,
 ):
     """Run only the dependency preflight on an existing bus or a temporary one.
 
@@ -285,8 +164,12 @@ async def install_plugins(
     ``config.json > required_binaries`` through abxpkg, without starting the
     later ``on_CrawlSetup__*`` or ``on_Snapshot__*`` plugin phases.
     """
-    if not plan.catalog:
+    if not catalog:
         return []
+
+    user_config = dict(config or {})
+    user_config["ABX_RUNTIME"] = runtime
+    install_timeout = compute_install_phase_timeout(get_install_plugins(catalog), user_config)
 
     install_output_dir = output_dir
     temp_dir_ctx = nullcontext(output_dir) if output_dir is not None else TemporaryDirectory(prefix="abx-dl-install-")
@@ -294,43 +177,152 @@ async def install_plugins(
     with temp_dir_ctx as temp_dir:
         install_output_dir = install_output_dir or Path(temp_dir)
         install_output_dir.mkdir(parents=True, exist_ok=True)
-        bus = bus or create_bus(total_timeout=plan.install_timeout)
+        bus = bus or create_bus(total_timeout=install_timeout)
         snapshot = Snapshot(url="")
-        plan.attach_services(
+        PluginBinaryEnvService(bus, catalog=catalog)
+        BinaryService(bus, auto_install=True)
+        PluginBinariesService(
             bus,
-            url="",
-            snapshot=snapshot,
-            output_dir=install_output_dir,
-            install_enabled=True,
-            crawl_setup_enabled=False,
-            crawl_start_enabled=False,
-            snapshot_cleanup_enabled=False,
-            crawl_cleanup_enabled=False,
+            catalog=catalog,
             auto_install=True,
+            install_plugins=get_install_plugins(catalog),
+            output_dir=install_output_dir,
+            snapshot=snapshot,
+        )
+        ProcessService(
+            bus,
             emit_jsonl=emit_jsonl,
             interactive_tty=sys.stdout.isatty() or sys.stderr.isatty(),
-            PluginBinariesService=PluginBinariesService,
-            PluginBinaryEnvService=PluginBinaryEnvService,
-            BinaryService=BinaryService,
-            ProcessService=ProcessService,
-            ArchiveResultService=None,
-            TagService=None,
         )
-        await plan.seed_config(bus)
+        await bus.emit(MachineEvent(config=user_config, config_type="user")).now()
+        if derived_config:
+            await bus.emit(MachineEvent(config=dict(derived_config), config_type="derived")).now()
         try:
             install_event = bus.emit(
                 InstallEvent(
                     url="",
                     snapshot_id=snapshot.id,
                     output_dir=str(install_output_dir),
-                    event_timeout=plan.install_timeout,
-                    event_handler_slow_timeout=slow_warning_timeout(plan.install_timeout),
+                    event_timeout=install_timeout,
+                    event_handler_slow_timeout=slow_warning_timeout(install_timeout),
                 ),
             )
-            await install_event.now(timeout=plan.install_timeout)
-            await install_event.wait(timeout=plan.install_timeout)
+            await install_event.now(timeout=install_timeout)
+            await install_event.wait(timeout=install_timeout)
             await install_event.event_results_list()
         finally:
+            await bus.wait_until_idle()
+
+
+async def parse_input(
+    source_text: str,
+    catalog: PluginCatalog,
+    output_dir: Path,
+    *,
+    config: dict[str, Any] | None = None,
+    derived_config: dict[str, Any] | None = None,
+    runtime: str = "abx-dl",
+    auto_install: bool = True,
+    bus: EventBus | None = None,
+    emit_jsonl: bool = False,
+) -> list[Snapshot]:
+    """Parse imported text through opted-in snapshot hooks and return URL facts.
+
+    The source is durably written to ``staticfile/stdin.txt``. Parser hooks run
+    against that real file URL using an in-memory Snapshot context; no database,
+    pseudo URL, crawl lifecycle, or persistent ingestion state is involved.
+    Returned facts retain hook metadata and are normalized to depth zero so a
+    collection application can persist them as initial crawl snapshots.
+    """
+
+    output_dir = output_dir.expanduser().resolve()
+    input_path = output_dir / "staticfile" / "stdin.txt"
+    input_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_input_path = input_path.with_name(f".{input_path.name}.{os.getpid()}.tmp")
+    temporary_input_path.write_text(source_text, encoding="utf-8")
+    temporary_input_path.replace(input_path)
+
+    parser_catalog = PluginCatalog(
+        {name: plugin for name, plugin in catalog.items() if plugin.config.x_accepts_internal_input and plugin.filter_hooks("Snapshot")},
+    )
+    if not parser_catalog:
+        return []
+
+    user_config = dict(config or {})
+    user_config["ABX_RUNTIME"] = runtime
+    runtime_config = RuntimeConfig(user=GlobalConfig(**user_config), derived=dict(derived_config or {}))
+    snapshot = Snapshot(url=input_path.as_uri())
+    install_timeout = compute_install_phase_timeout(get_install_plugins(parser_catalog), user_config)
+    snapshot_hooks = [(plugin, hook) for plugin in parser_catalog.values() for hook in plugin.filter_hooks("Snapshot")]
+    snapshot_timeout = compute_phase_timeout(snapshot_hooks, user_config)
+    owns_bus = bus is None
+    bus = bus or create_bus(total_timeout=install_timeout + (snapshot_timeout * 2), name=f"AbxDlInput_{snapshot.id}")
+
+    PluginBinaryEnvService(bus, catalog=parser_catalog)
+    BinaryService(bus, auto_install=auto_install)
+    PluginBinariesService(
+        bus,
+        catalog=parser_catalog,
+        auto_install=auto_install,
+        install_plugins=get_install_plugins(parser_catalog),
+        output_dir=output_dir,
+        snapshot=snapshot,
+    )
+    ProcessService(bus, emit_jsonl=emit_jsonl, interactive_tty=False)
+    ArchiveResultService(bus, emit_jsonl=emit_jsonl)
+    TagService(bus)
+    SnapshotService(
+        bus,
+        url=snapshot.url,
+        snapshot=snapshot,
+        output_dir=output_dir,
+        catalog=parser_catalog,
+        config=runtime_config,
+        snapshot_phase_timeout=snapshot_timeout,
+        snapshot_cleanup_phase_timeout=snapshot_timeout,
+    )
+    await bus.emit(MachineEvent(config=user_config, config_type="user")).now()
+    if derived_config:
+        await bus.emit(MachineEvent(config=dict(derived_config), config_type="derived")).now()
+
+    try:
+        install_event = bus.emit(
+            InstallEvent(
+                url=snapshot.url,
+                snapshot_id=snapshot.id,
+                output_dir=str(output_dir),
+                event_timeout=install_timeout,
+                event_handler_slow_timeout=slow_warning_timeout(install_timeout),
+            ),
+        )
+        await install_event.now(timeout=install_timeout)
+        await install_event.wait(timeout=install_timeout)
+        await install_event.event_results_list()
+        await bus.wait_until_idle()
+
+        snapshot_event = bus.emit(
+            SnapshotEvent(
+                url=snapshot.url,
+                snapshot_id=snapshot.id,
+                output_dir=str(output_dir),
+                depth=0,
+                event_timeout=snapshot_timeout,
+                event_handler_slow_timeout=slow_warning_timeout(snapshot_timeout),
+            ),
+        )
+        await snapshot_event.now(timeout=snapshot_timeout)
+        await snapshot_event.wait(timeout=snapshot_timeout)
+        await snapshot_event.event_results_list()
+        await bus.wait_until_idle()
+        discoveries = await bus.filter(
+            SnapshotDiscoveredEvent,
+            child_of=snapshot_event,
+            past=True,
+            future=False,
+        )
+        return [event.snapshot.model_copy(update={"depth": 0}) for event in reversed(discoveries)]
+    finally:
+        if owns_bus:
             await bus.wait_until_idle()
 
 
@@ -375,128 +367,6 @@ def compute_phase_timeout(hooks: list[tuple[Plugin, Hook]], config: dict[str, An
     """
     total = sum(get_plugin_timeout(plugin, config) for plugin, _hook in hooks)
     return max(float(total), 60.0)
-
-
-@dataclass(frozen=True)
-class ExecutionPlan:
-    """Framework-neutral description of one configured plugin execution.
-
-    Embedders own persistence and scheduling.  The plan owns the shared plugin
-    selection, config seed, and timeout calculations required to attach abx-dl
-    services to their EventBus.
-    """
-
-    catalog: PluginCatalog
-    config: dict[str, Any]
-    derived_config: dict[str, Any]
-    runtime: str
-    install_timeout: float
-    crawl_setup_timeout: float
-    snapshot_timeout: float
-    crawl_cleanup_timeout: float
-
-    @classmethod
-    def build(
-        cls,
-        catalog: PluginCatalog,
-        *,
-        selected_plugins: Iterable[str] | None = None,
-        disabled_plugins: Iterable[str] = (),
-        config: dict[str, Any] | None = None,
-        derived_config: dict[str, Any] | None = None,
-        runtime: str = "abx-dl",
-    ) -> ExecutionPlan:
-        selected = catalog.select(selected_plugins, disabled_names=disabled_plugins)
-        runtime_config = dict(config or {})
-        # The embedding application owns runtime identity. Do not let an env
-        # value make hooks believe a standalone run is ArchiveBox (or vice
-        # versa) after plugin discovery already used this explicit runtime.
-        runtime_config["ABX_RUNTIME"] = runtime
-        crawl_setup_hooks = [(plugin, hook) for plugin in selected.values() for hook in plugin.filter_hooks("CrawlSetup")]
-        snapshot_hooks = [(plugin, hook) for plugin in selected.values() for hook in plugin.filter_hooks("Snapshot")]
-        return cls(
-            catalog=selected,
-            config=runtime_config,
-            derived_config=dict(derived_config or {}),
-            runtime=runtime,
-            install_timeout=compute_install_phase_timeout(get_install_plugins(selected), runtime_config),
-            crawl_setup_timeout=compute_phase_timeout(crawl_setup_hooks, runtime_config),
-            snapshot_timeout=compute_phase_timeout(snapshot_hooks, runtime_config),
-            crawl_cleanup_timeout=compute_phase_timeout(crawl_setup_hooks, runtime_config),
-        )
-
-    @property
-    def runtime_config(self) -> RuntimeConfig:
-        return RuntimeConfig(
-            user=GlobalConfig(**self.config),
-            derived=dict(self.derived_config),
-        )
-
-    async def seed_config(self, bus: EventBus, *, parent_event: Any | None = None) -> None:
-        """Publish the plan's config layers through the normal runtime contract."""
-        user_event = MachineEvent(config=dict(self.config), config_type="user")
-        if parent_event is not None:
-            user_event.event_parent_id = parent_event.event_id
-        await bus.emit(user_event).now()
-        if self.derived_config:
-            derived_event = MachineEvent(config=dict(self.derived_config), config_type="derived")
-            if parent_event is not None:
-                derived_event.event_parent_id = parent_event.event_id
-            await bus.emit(derived_event).now()
-
-    def attach_services(
-        self,
-        bus: EventBus,
-        *,
-        url: str | None = None,
-        snapshot: Snapshot | None = None,
-        output_dir: Path | None = None,
-        **service_options: Any,
-    ) -> None:
-        """Attach shared services using this plan's single selected/configured view."""
-        _attach_services(
-            bus,
-            catalog=self.catalog,
-            url=url,
-            snapshot=snapshot,
-            output_dir=output_dir,
-            runtime_config=self.runtime_config,
-            crawl_setup_phase_timeout=self.crawl_setup_timeout,
-            snapshot_phase_timeout=self.snapshot_timeout,
-            snapshot_cleanup_phase_timeout=self.snapshot_timeout,
-            crawl_cleanup_phase_timeout=self.crawl_cleanup_timeout,
-            **service_options,
-        )
-
-    def attach_snapshot_service(
-        self,
-        bus: EventBus,
-        *,
-        url: str,
-        snapshot: Snapshot,
-        output_dir: Path,
-        snapshot_service: type[SnapshotService] = SnapshotService,
-        timeout_padding: float = 0.0,
-        abort_requested: Any | None = None,
-        selected_hooks_by_plugin: dict[str, set[str] | None] | None = None,
-        emit_discovered_snapshot_events: bool = True,
-    ) -> SnapshotService:
-        """Attach one snapshot executor to an existing application-owned bus."""
-        timeout = self.snapshot_timeout + timeout_padding
-        return snapshot_service(
-            bus,
-            url=url,
-            snapshot=snapshot,
-            output_dir=output_dir,
-            catalog=self.catalog,
-            config=self.runtime_config,
-            snapshot_phase_timeout=timeout,
-            snapshot_cleanup_enabled=True,
-            snapshot_cleanup_phase_timeout=timeout,
-            abort_requested=abort_requested,
-            selected_hooks_by_plugin=selected_hooks_by_plugin,
-            emit_discovered_snapshot_events=emit_discovered_snapshot_events,
-        )
 
 
 def create_bus(
@@ -557,27 +427,16 @@ def create_bus(
 
 async def download(
     url: str,
-    plan: ExecutionPlan,
+    catalog: PluginCatalog,
     output_dir: Path,
     auto_install: bool = True,
     *,
+    config: dict[str, Any] | None = None,
+    derived_config: dict[str, Any] | None = None,
+    runtime: str = "abx-dl",
     bus: EventBus | None = None,
     emit_jsonl: bool | None = None,
     interactive_tty: bool | None = None,
-    crawl_setup_enabled: bool = True,
-    crawl_start_enabled: bool = True,
-    snapshot_cleanup_enabled: bool = True,
-    crawl_cleanup_enabled: bool = True,
-    crawl_completed_enabled: bool = True,
-    crawl_event_enabled: bool = True,
-    PluginBinariesService: type[PluginBinariesService] | None = PluginBinariesService,
-    PluginBinaryEnvService: type[PluginBinaryEnvService] | None = PluginBinaryEnvService,
-    BinaryService: type[BinaryService] | None = BinaryService,
-    ProcessService: type[ProcessService] | None = ProcessService,
-    ArchiveResultService: type[ArchiveResultService] | None = ArchiveResultService,
-    TagService: type[TagService] | None = TagService,
-    CrawlService: type[CrawlService] | None = CrawlService,
-    SnapshotService: type[SnapshotService] | None = SnapshotService,
 ):
     """Download a URL using plugins, coordinated through a abxbus EventBus.
 
@@ -586,12 +445,12 @@ async def download(
     2. Wires up all services on the bus
     3. Emits InstallEvent for dependency preflight, then CrawlEvent for the
        CrawlSetup → CrawlStart → Snapshot →
-       SnapshotCleanup → CrawlCleanup sequence (unless phase flags request a subset)
+       SnapshotCleanup → CrawlCleanup sequence
     4. Leaves all result collection to bus subscribers attached during setup
 
     Args:
         url: The URL to download/archive.
-        plan: The selected, configured plugin execution plan.
+        catalog: The selected plugins to execute.
         output_dir: Where to write output files and index.jsonl.
         auto_install: Whether to auto-install missing binaries.
         bus: Pre-configured EventBus to run against. If None, a default bus is
@@ -613,11 +472,16 @@ async def download(
         emit_jsonl = not stdout_is_tty
     if interactive_tty is None:
         interactive_tty = stdout_is_tty or sys.stderr.isatty()
+    assert isinstance(interactive_tty, bool)
+
+    user_config = dict(config or {})
+    user_config["ABX_RUNTIME"] = runtime
+    runtime_config = RuntimeConfig(user=GlobalConfig(**user_config), derived=dict(derived_config or {}))
 
     # Create snapshot record and write it as the first line of index.jsonl
     snapshot_payload: dict[str, Any] = {"url": url}
-    if plan.config.get("EXTRA_CONTEXT"):
-        extra_context = plan.config["EXTRA_CONTEXT"]
+    if user_config.get("EXTRA_CONTEXT"):
+        extra_context = user_config["EXTRA_CONTEXT"]
         if isinstance(extra_context, str):
             extra_context = json.loads(extra_context)
         if not isinstance(extra_context, dict):
@@ -631,17 +495,19 @@ async def download(
     snapshot = Snapshot(**snapshot_payload)
     write_jsonl(index_path, snapshot, also_print=emit_jsonl)
 
-    install_phase_timeout = plan.install_timeout
-    crawl_setup_phase_timeout = plan.crawl_setup_timeout
-    snapshot_phase_timeout = plan.snapshot_timeout
+    crawl_setup_hooks = [(plugin, hook) for plugin in catalog.values() for hook in plugin.filter_hooks("CrawlSetup")]
+    snapshot_hooks = [(plugin, hook) for plugin in catalog.values() for hook in plugin.filter_hooks("Snapshot")]
+    install_phase_timeout = compute_install_phase_timeout(get_install_plugins(catalog), user_config)
+    crawl_setup_phase_timeout = compute_phase_timeout(crawl_setup_hooks, user_config)
+    snapshot_phase_timeout = compute_phase_timeout(snapshot_hooks, user_config)
     snapshot_cleanup_phase_timeout = snapshot_phase_timeout
-    crawl_cleanup_phase_timeout = plan.crawl_cleanup_timeout
+    crawl_cleanup_phase_timeout = crawl_setup_phase_timeout
     total_timeout = (
         install_phase_timeout
-        + (crawl_setup_phase_timeout if crawl_setup_enabled else 0.0)
-        + (snapshot_phase_timeout if crawl_start_enabled else 0.0)
-        + (snapshot_cleanup_phase_timeout if snapshot_cleanup_enabled else 0.0)
-        + (crawl_cleanup_phase_timeout if crawl_cleanup_enabled else 0.0)
+        + crawl_setup_phase_timeout
+        + snapshot_phase_timeout
+        + snapshot_cleanup_phase_timeout
+        + crawl_cleanup_phase_timeout
     )
 
     owns_bus = bus is None
@@ -649,31 +515,42 @@ async def download(
         bus = create_bus(total_timeout=total_timeout)
     assert bus is not None
 
-    plan.attach_services(
+    PluginBinaryEnvService(bus, catalog=catalog)
+    BinaryService(bus, auto_install=auto_install)
+    PluginBinariesService(
+        bus,
+        catalog=catalog,
+        auto_install=auto_install,
+        install_plugins=get_install_plugins(catalog),
+        output_dir=output_dir,
+        snapshot=snapshot,
+    )
+    ProcessService(bus, emit_jsonl=emit_jsonl, interactive_tty=interactive_tty)
+    ArchiveResultService(bus, emit_jsonl=emit_jsonl)
+    TagService(bus)
+    CrawlService(bus, url=url, snapshot=snapshot, output_dir=output_dir, catalog=catalog)
+    SnapshotService(
         bus,
         url=url,
         snapshot=snapshot,
         output_dir=output_dir,
-        install_enabled=True,
-        crawl_setup_enabled=crawl_setup_enabled,
-        crawl_start_enabled=crawl_start_enabled,
-        snapshot_cleanup_enabled=snapshot_cleanup_enabled,
-        crawl_cleanup_enabled=crawl_cleanup_enabled,
-        crawl_completed_enabled=crawl_completed_enabled,
-        crawl_event_enabled=crawl_event_enabled,
-        auto_install=auto_install,
-        emit_jsonl=emit_jsonl,
-        interactive_tty=interactive_tty,
-        PluginBinariesService=PluginBinariesService,
-        PluginBinaryEnvService=PluginBinaryEnvService,
-        BinaryService=BinaryService,
-        ProcessService=ProcessService,
-        ArchiveResultService=ArchiveResultService,
-        TagService=TagService,
-        CrawlService=CrawlService,
-        SnapshotService=SnapshotService,
+        catalog=catalog,
+        config=runtime_config,
+        snapshot_phase_timeout=snapshot_phase_timeout,
+        snapshot_cleanup_phase_timeout=snapshot_cleanup_phase_timeout,
     )
-    await plan.seed_config(bus)
+    CrawlLifecycleService(
+        bus,
+        url=url,
+        snapshot=snapshot,
+        output_dir=output_dir,
+        crawl_setup_phase_timeout=crawl_setup_phase_timeout,
+        snapshot_phase_timeout=snapshot_phase_timeout,
+        crawl_cleanup_phase_timeout=crawl_cleanup_phase_timeout,
+    )
+    await bus.emit(MachineEvent(config=user_config, config_type="user")).now()
+    if derived_config:
+        await bus.emit(MachineEvent(config=dict(derived_config), config_type="derived")).now()
 
     try:
         install_event = bus.emit(
@@ -689,22 +566,17 @@ async def download(
         await install_event.wait(timeout=install_phase_timeout)
         await install_event.event_results_list()
         await bus.wait_until_idle()
-        if crawl_setup_enabled or crawl_start_enabled or crawl_cleanup_enabled:
-            crawl_event_timeout = (
-                (crawl_setup_phase_timeout if crawl_setup_enabled else 0.0)
-                + (snapshot_phase_timeout if crawl_start_enabled else 0.0)
-                + (crawl_cleanup_phase_timeout if crawl_cleanup_enabled else 0.0)
-            )
-            crawl_event = CrawlEvent(
-                url=url,
-                snapshot_id=snapshot.id,
-                output_dir=str(output_dir),
-                event_timeout=crawl_event_timeout,
-                event_handler_slow_timeout=slow_warning_timeout(crawl_event_timeout),
-            )
-            emitted_crawl_event = bus.emit(crawl_event)
-            await emitted_crawl_event.now()
-            await emitted_crawl_event.event_results_list()
+        crawl_event_timeout = crawl_setup_phase_timeout + snapshot_phase_timeout + crawl_cleanup_phase_timeout
+        crawl_event = CrawlEvent(
+            url=url,
+            snapshot_id=snapshot.id,
+            output_dir=str(output_dir),
+            event_timeout=crawl_event_timeout,
+            event_handler_slow_timeout=slow_warning_timeout(crawl_event_timeout),
+        )
+        emitted_crawl_event = bus.emit(crawl_event)
+        await emitted_crawl_event.now()
+        await emitted_crawl_event.event_results_list()
     finally:
         if owns_bus:
             await bus.wait_until_idle()

--- a/abx_dl/orchestrator.py
+++ b/abx_dl/orchestrator.py
@@ -114,6 +114,21 @@ def get_install_plugins(catalog: PluginCatalog) -> list[Plugin]:
     return [plugin for plugin in catalog.values() if plugin.config.required_binaries]
 
 
+def _claim_fresh_bus(bus: EventBus, operation: str) -> None:
+    """Reserve a caller-provided bus for one orchestration run.
+
+    Orchestrator services remain attached so callers can inspect event history
+    after completion. Reusing that bus would register a second listener suite
+    and execute hooks more than once, so fail before attaching any services.
+    """
+    previous_operation = getattr(bus, "_abx_dl_orchestrator_operation", None)
+    if previous_operation is not None:
+        raise RuntimeError(
+            f"EventBus was already used by {previous_operation}; create a fresh EventBus for each orchestration call",
+        )
+    setattr(bus, "_abx_dl_orchestrator_operation", operation)
+
+
 def _positive_int(value: Any) -> int | None:
     try:
         parsed = int(value)
@@ -178,6 +193,7 @@ async def install_plugins(
         install_output_dir = install_output_dir or Path(temp_dir)
         install_output_dir.mkdir(parents=True, exist_ok=True)
         bus = bus or create_bus(total_timeout=install_timeout)
+        _claim_fresh_bus(bus, "install_plugins")
         snapshot = Snapshot(url="")
         PluginBinaryEnvService(bus, catalog=catalog)
         BinaryService(bus, auto_install=True)
@@ -257,6 +273,7 @@ async def parse_input(
     snapshot_timeout = compute_phase_timeout(snapshot_hooks, user_config)
     owns_bus = bus is None
     bus = bus or create_bus(total_timeout=install_timeout + (snapshot_timeout * 2), name=f"AbxDlInput_{snapshot.id}")
+    _claim_fresh_bus(bus, "parse_input")
 
     PluginBinaryEnvService(bus, catalog=parser_catalog)
     BinaryService(bus, auto_install=auto_install)
@@ -478,7 +495,7 @@ async def download(
     user_config["ABX_RUNTIME"] = runtime
     runtime_config = RuntimeConfig(user=GlobalConfig(**user_config), derived=dict(derived_config or {}))
 
-    # Create snapshot record and write it as the first line of index.jsonl
+    # Create the snapshot record that owns this run.
     snapshot_payload: dict[str, Any] = {"url": url}
     if user_config.get("EXTRA_CONTEXT"):
         extra_context = user_config["EXTRA_CONTEXT"]
@@ -493,7 +510,6 @@ async def download(
         if "crawl_id" in extra_context:
             snapshot_payload["crawl_id"] = str(extra_context["crawl_id"])
     snapshot = Snapshot(**snapshot_payload)
-    write_jsonl(index_path, snapshot, also_print=emit_jsonl)
 
     crawl_setup_hooks = [(plugin, hook) for plugin in catalog.values() for hook in plugin.filter_hooks("CrawlSetup")]
     snapshot_hooks = [(plugin, hook) for plugin in catalog.values() for hook in plugin.filter_hooks("Snapshot")]
@@ -514,6 +530,10 @@ async def download(
     if bus is None:
         bus = create_bus(total_timeout=total_timeout)
     assert bus is not None
+    _claim_fresh_bus(bus, "download")
+
+    # Keep the owning snapshot as the first line of index.jsonl.
+    write_jsonl(index_path, snapshot, also_print=emit_jsonl)
 
     PluginBinaryEnvService(bus, catalog=catalog)
     BinaryService(bus, auto_install=auto_install)

--- a/abx_dl/orchestrator.py
+++ b/abx_dl/orchestrator.py
@@ -114,6 +114,11 @@ def get_install_plugins(catalog: PluginCatalog) -> list[Plugin]:
     return [plugin for plugin in catalog.values() if plugin.config.required_binaries]
 
 
+def get_phase_hooks(catalog: PluginCatalog, phase: str) -> list[tuple[Plugin, Hook]]:
+    """Return every hook selected for one lifecycle phase."""
+    return [(plugin, hook) for plugin in catalog.values() for hook in plugin.filter_hooks(phase)]
+
+
 def _claim_fresh_bus(bus: EventBus, operation: str) -> None:
     """Reserve a caller-provided bus for one orchestration run.
 
@@ -269,7 +274,7 @@ async def parse_input(
     runtime_config = RuntimeConfig(user=GlobalConfig(**user_config), derived=dict(derived_config or {}))
     snapshot = Snapshot(url=input_path.as_uri())
     install_timeout = compute_install_phase_timeout(get_install_plugins(parser_catalog), user_config)
-    snapshot_hooks = [(plugin, hook) for plugin in parser_catalog.values() for hook in plugin.filter_hooks("Snapshot")]
+    snapshot_hooks = get_phase_hooks(parser_catalog, "Snapshot")
     snapshot_timeout = compute_phase_timeout(snapshot_hooks, user_config)
     owns_bus = bus is None
     bus = bus or create_bus(total_timeout=install_timeout + (snapshot_timeout * 2), name=f"AbxDlInput_{snapshot.id}")
@@ -511,8 +516,8 @@ async def download(
             snapshot_payload["crawl_id"] = str(extra_context["crawl_id"])
     snapshot = Snapshot(**snapshot_payload)
 
-    crawl_setup_hooks = [(plugin, hook) for plugin in catalog.values() for hook in plugin.filter_hooks("CrawlSetup")]
-    snapshot_hooks = [(plugin, hook) for plugin in catalog.values() for hook in plugin.filter_hooks("Snapshot")]
+    crawl_setup_hooks = get_phase_hooks(catalog, "CrawlSetup")
+    snapshot_hooks = get_phase_hooks(catalog, "Snapshot")
     install_phase_timeout = compute_install_phase_timeout(get_install_plugins(catalog), user_config)
     crawl_setup_phase_timeout = compute_phase_timeout(crawl_setup_hooks, user_config)
     snapshot_phase_timeout = compute_phase_timeout(snapshot_hooks, user_config)

--- a/abx_dl/services/__init__.py
+++ b/abx_dl/services/__init__.py
@@ -4,6 +4,7 @@ from .archive_result_service import ArchiveResultService
 from .base import BaseService
 from .binary_service import PluginBinariesService, PluginBinaryEnvService
 from .crawl_service import CrawlService
+from .crawl_lifecycle_service import CrawlLifecycleService
 from .process_service import ProcessService
 from .snapshot_service import SnapshotService
 from .tag_service import TagService
@@ -13,6 +14,7 @@ __all__ = [
     "BaseService",
     "PluginBinaryEnvService",
     "CrawlService",
+    "CrawlLifecycleService",
     "ProcessService",
     "SnapshotService",
     "TagService",

--- a/abx_dl/services/crawl_lifecycle_service.py
+++ b/abx_dl/services/crawl_lifecycle_service.py
@@ -1,0 +1,169 @@
+"""Standalone crawl lifecycle event sequencing."""
+
+from collections.abc import Awaitable, Callable
+from inspect import isawaitable
+from pathlib import Path
+from typing import ClassVar
+
+from abxbus import BaseEvent, EventBus
+
+from ..events import (
+    CrawlAbortEvent,
+    CrawlCleanupEvent,
+    CrawlCompletedEvent,
+    CrawlEvent,
+    CrawlStartEvent,
+    CrawlSetupEvent,
+    SnapshotCompletedEvent,
+    SnapshotEvent,
+    slow_warning_timeout,
+)
+from ..models import Snapshot
+from .base import BaseService
+
+
+async def _run_event_now(event: BaseEvent, timeout: float | None = None) -> BaseEvent:
+    await event.now(timeout=timeout)
+    await event.wait(timeout=timeout)
+    await event.event_results_list()
+    return event
+
+
+class CrawlLifecycleService(BaseService):
+    """Expand a root ``CrawlEvent`` into the standalone lifecycle phases."""
+
+    LISTENS_TO: ClassVar[list[type[BaseEvent]]] = [CrawlEvent, CrawlAbortEvent, CrawlStartEvent]
+    EMITS: ClassVar[list[type[BaseEvent]]] = [
+        CrawlSetupEvent,
+        CrawlStartEvent,
+        CrawlCleanupEvent,
+        CrawlCompletedEvent,
+        SnapshotEvent,
+    ]
+
+    def __init__(
+        self,
+        bus: EventBus,
+        *,
+        url: str,
+        snapshot: Snapshot,
+        output_dir: Path,
+        crawl_setup_phase_timeout: float = 300.0,
+        snapshot_phase_timeout: float = 300.0,
+        crawl_cleanup_phase_timeout: float = 300.0,
+        abort_requested: Callable[[], bool | Awaitable[bool]] | None = None,
+    ) -> None:
+        self.url = url
+        self.snapshot = snapshot
+        self.output_dir = output_dir
+        self.crawl_setup_phase_timeout = crawl_setup_phase_timeout
+        self.snapshot_phase_timeout = snapshot_phase_timeout
+        self.crawl_cleanup_phase_timeout = crawl_cleanup_phase_timeout
+        self.abort_requested = False
+        self.abort_requested_callback = abort_requested
+        self._active_crawl_event_ids: set[str] = set()
+        self._completed_crawl_event_ids: set[str] = set()
+        super().__init__(bus)
+        self.bus.on(CrawlEvent, self.on_CrawlEvent)
+        self.bus.on(CrawlAbortEvent, self.on_CrawlAbortEvent)
+        self.bus.on(CrawlStartEvent, self.on_CrawlStartEvent)
+
+    async def should_abort(self) -> bool:
+        if self.abort_requested:
+            return True
+        if self.abort_requested_callback is None:
+            return False
+        callback_result = self.abort_requested_callback()
+        if isawaitable(callback_result):
+            callback_result = await callback_result
+        if bool(callback_result):
+            self.abort_requested = True
+            return True
+        return False
+
+    async def on_CrawlEvent(self, event: CrawlEvent) -> None:
+        if event.output_dir != str(self.output_dir):
+            return
+        if event.event_id in self._active_crawl_event_ids or event.event_id in self._completed_crawl_event_ids:
+            return
+        self._active_crawl_event_ids.add(event.event_id)
+        try:
+            await self._run_root_crawl_event(event)
+        finally:
+            self._active_crawl_event_ids.discard(event.event_id)
+            self._completed_crawl_event_ids.add(event.event_id)
+
+    async def _run_root_crawl_event(self, event: CrawlEvent) -> None:
+        await _run_event_now(
+            event.emit(
+                CrawlSetupEvent(
+                    url=self.url,
+                    snapshot_id=self.snapshot.id,
+                    output_dir=str(self.output_dir),
+                    event_timeout=self.crawl_setup_phase_timeout,
+                    event_handler_slow_timeout=slow_warning_timeout(self.crawl_setup_phase_timeout),
+                ),
+            ),
+            self.crawl_setup_phase_timeout,
+        )
+        if not await self.should_abort():
+            await _run_event_now(
+                event.emit(
+                    CrawlStartEvent(
+                        url=self.url,
+                        snapshot_id=self.snapshot.id,
+                        output_dir=str(self.output_dir),
+                        event_timeout=self.snapshot_phase_timeout,
+                        event_handler_slow_timeout=slow_warning_timeout(self.snapshot_phase_timeout),
+                    ),
+                ),
+                self.snapshot_phase_timeout,
+            )
+        await _run_event_now(
+            event.emit(
+                CrawlCleanupEvent(
+                    url=self.url,
+                    snapshot_id=self.snapshot.id,
+                    output_dir=str(self.output_dir),
+                    event_timeout=self.crawl_cleanup_phase_timeout,
+                    event_handler_slow_timeout=slow_warning_timeout(self.crawl_cleanup_phase_timeout),
+                ),
+            ),
+            self.crawl_cleanup_phase_timeout,
+        )
+        await _run_event_now(
+            event.emit(
+                CrawlCompletedEvent(
+                    url=self.url,
+                    snapshot_id=self.snapshot.id,
+                    output_dir=str(self.output_dir),
+                ),
+            ),
+            CrawlCompletedEvent.model_fields["event_timeout"].default,
+        )
+
+    async def on_CrawlStartEvent(self, event: CrawlStartEvent) -> None:
+        if event.output_dir != str(self.output_dir) or await self.should_abort():
+            return
+        snapshot_event = event.emit(
+            SnapshotEvent(
+                url=self.url,
+                snapshot_id=self.snapshot.id,
+                output_dir=str(self.output_dir),
+                depth=0,
+                event_timeout=event.event_timeout,
+                event_handler_slow_timeout=slow_warning_timeout(event.event_timeout),
+            ),
+        )
+        await _run_event_now(snapshot_event, event.event_timeout)
+        completed_snapshot = await self.bus.find(
+            SnapshotCompletedEvent,
+            child_of=snapshot_event,
+            past=True,
+            future=event.event_timeout,
+        )
+        if completed_snapshot is None:
+            raise RuntimeError(f"Snapshot {self.snapshot.id} did not complete")
+
+    async def on_CrawlAbortEvent(self, event: CrawlAbortEvent) -> None:
+        self.abort_requested = True

--- a/abx_dl/services/crawl_lifecycle_service.py
+++ b/abx_dl/services/crawl_lifecycle_service.py
@@ -82,7 +82,7 @@ class CrawlLifecycleService(BaseService):
         return False
 
     async def on_CrawlEvent(self, event: CrawlEvent) -> None:
-        if event.output_dir != str(self.output_dir):
+        if event.output_dir != str(self.output_dir) or event.snapshot_id != self.snapshot.id:
             return
         if event.event_id in self._active_crawl_event_ids or event.event_id in self._completed_crawl_event_ids:
             return
@@ -94,31 +94,51 @@ class CrawlLifecycleService(BaseService):
             self._completed_crawl_event_ids.add(event.event_id)
 
     async def _run_root_crawl_event(self, event: CrawlEvent) -> None:
-        await _run_event_now(
-            event.emit(
-                CrawlSetupEvent(
-                    url=self.url,
-                    snapshot_id=self.snapshot.id,
-                    output_dir=str(self.output_dir),
-                    event_timeout=self.crawl_setup_phase_timeout,
-                    event_handler_slow_timeout=slow_warning_timeout(self.crawl_setup_phase_timeout),
-                ),
-            ),
-            self.crawl_setup_phase_timeout,
-        )
-        if not await self.should_abort():
+        try:
             await _run_event_now(
                 event.emit(
-                    CrawlStartEvent(
+                    CrawlSetupEvent(
                         url=self.url,
                         snapshot_id=self.snapshot.id,
                         output_dir=str(self.output_dir),
-                        event_timeout=self.snapshot_phase_timeout,
-                        event_handler_slow_timeout=slow_warning_timeout(self.snapshot_phase_timeout),
+                        event_timeout=self.crawl_setup_phase_timeout,
+                        event_handler_slow_timeout=slow_warning_timeout(self.crawl_setup_phase_timeout),
                     ),
                 ),
-                self.snapshot_phase_timeout,
+                self.crawl_setup_phase_timeout,
             )
+            if not await self.should_abort():
+                await _run_event_now(
+                    event.emit(
+                        CrawlStartEvent(
+                            url=self.url,
+                            snapshot_id=self.snapshot.id,
+                            output_dir=str(self.output_dir),
+                            event_timeout=self.snapshot_phase_timeout,
+                            event_handler_slow_timeout=slow_warning_timeout(self.snapshot_phase_timeout),
+                        ),
+                    ),
+                    self.snapshot_phase_timeout,
+                )
+        except BaseException as phase_error:
+            try:
+                await self._run_cleanup(event)
+            except BaseException as cleanup_error:
+                phase_error.add_note(f"Crawl cleanup also failed: {cleanup_error}")
+            raise
+        await self._run_cleanup(event)
+        await _run_event_now(
+            event.emit(
+                CrawlCompletedEvent(
+                    url=self.url,
+                    snapshot_id=self.snapshot.id,
+                    output_dir=str(self.output_dir),
+                ),
+            ),
+            CrawlCompletedEvent.model_fields["event_timeout"].default,
+        )
+
+    async def _run_cleanup(self, event: CrawlEvent) -> None:
         await _run_event_now(
             event.emit(
                 CrawlCleanupEvent(
@@ -131,19 +151,9 @@ class CrawlLifecycleService(BaseService):
             ),
             self.crawl_cleanup_phase_timeout,
         )
-        await _run_event_now(
-            event.emit(
-                CrawlCompletedEvent(
-                    url=self.url,
-                    snapshot_id=self.snapshot.id,
-                    output_dir=str(self.output_dir),
-                ),
-            ),
-            CrawlCompletedEvent.model_fields["event_timeout"].default,
-        )
 
     async def on_CrawlStartEvent(self, event: CrawlStartEvent) -> None:
-        if event.output_dir != str(self.output_dir) or await self.should_abort():
+        if event.output_dir != str(self.output_dir) or event.snapshot_id != self.snapshot.id or await self.should_abort():
             return
         snapshot_event = event.emit(
             SnapshotEvent(

--- a/abx_dl/services/crawl_service.py
+++ b/abx_dl/services/crawl_service.py
@@ -1,4 +1,4 @@
-"""CrawlService — orchestrates the install + crawl lifecycle phases."""
+"""Plugin crawl-hook execution and cleanup listeners."""
 
 import asyncio
 from inspect import isawaitable
@@ -13,16 +13,12 @@ from ..config import get_config, get_plugin_env
 from ..events import (
     CrawlAbortEvent,
     CrawlCleanupEvent,
-    CrawlCompletedEvent,
     CrawlEvent,
-    CrawlStartEvent,
     CrawlSetupEvent,
     ProcessCompletedEvent,
     ProcessEvent,
     ProcessKillEvent,
     ProcessStartedEvent,
-    SnapshotCompletedEvent,
-    SnapshotEvent,
     slow_warning_timeout,
 )
 from ..models import Snapshot
@@ -47,43 +43,21 @@ async def _run_event_now(event: BaseEvent, timeout: float | None = None) -> Base
 
 
 class CrawlService(BaseService):
-    """Orchestrates the crawl lifecycle.
+    """Run plugin ``CrawlSetup`` hooks and clean up their processes.
 
-    Lifecycle::
-
-        CrawlEvent                                    # emitted by orchestrator
-        │
-        ├── CrawlSetupEvent                           # on_CrawlSetup hooks run here
-        │   ├── on_CrawlSetup__90_chrome_launch.daemon.bg
-        │   └── on_CrawlSetup__91_chrome_wait
-        │
-        ├── CrawlStartEvent                  # triggers snapshot phase
-        │   └── SnapshotEvent (full snapshot lifecycle)
-        │
-        ├── CrawlCleanupEvent                         # SIGTERMs bg crawl daemons
-        │   └── ProcessKillEvent × N
-        │
-        └── CrawlCompletedEvent                       # informational
-
-    CrawlEvent is the root crawl-lifecycle driver. Crawl setup per-hook handlers
-    are registered on CrawlSetupEvent so phase ordering stays explicit.
+    This service deliberately does not drive the crawl lifecycle. Embedders can
+    attach it wherever plugin crawl hooks are wanted; standalone downloads also
+    attach :class:`CrawlLifecycleService` to emit the phase events.
     """
 
     LISTENS_TO: ClassVar[list[type[BaseEvent]]] = [
-        CrawlEvent,
         CrawlAbortEvent,
         CrawlSetupEvent,
-        CrawlStartEvent,
         CrawlCleanupEvent,
     ]
     EMITS: ClassVar[list[type[BaseEvent]]] = [
-        CrawlSetupEvent,
-        CrawlStartEvent,
-        CrawlCleanupEvent,
-        CrawlCompletedEvent,
         ProcessEvent,
         ProcessKillEvent,
-        SnapshotEvent,
     ]
 
     def __init__(
@@ -94,15 +68,6 @@ class CrawlService(BaseService):
         snapshot: Snapshot,
         output_dir: Path,
         catalog: PluginCatalog,
-        crawl_setup_enabled: bool = True,
-        crawl_start_enabled: bool = True,
-        crawl_cleanup_enabled: bool = True,
-        crawl_completed_enabled: bool = True,
-        crawl_event_enabled: bool = True,
-        crawl_setup_phase_timeout: float = 300.0,
-        snapshot_phase_timeout: float = 300.0,
-        snapshot_cleanup_phase_timeout: float = 300.0,
-        crawl_cleanup_phase_timeout: float = 300.0,
         abort_requested: Callable[[], bool | Awaitable[bool]] | None = None,
     ):
         self.url = url
@@ -114,25 +79,11 @@ class CrawlService(BaseService):
             for hook in plugin.filter_hooks("CrawlSetup"):
                 self.crawl_setup_hooks.append((plugin, hook))
         self.crawl_setup_hooks.sort(key=lambda item: item[1].sort_key)
-        self.crawl_setup_enabled = crawl_setup_enabled
-        self.crawl_start_enabled = crawl_start_enabled
-        self.crawl_cleanup_enabled = crawl_cleanup_enabled
-        self.crawl_completed_enabled = crawl_completed_enabled
-        self.crawl_event_enabled = crawl_event_enabled
-        self.crawl_setup_phase_timeout = crawl_setup_phase_timeout
-        self.snapshot_phase_timeout = snapshot_phase_timeout
-        self.snapshot_cleanup_phase_timeout = snapshot_cleanup_phase_timeout
-        self.crawl_cleanup_phase_timeout = crawl_cleanup_phase_timeout
         self.abort_requested = False
         self.abort_requested_callback = abort_requested
-        self._active_crawl_event_ids: set[str] = set()
-        self._completed_crawl_event_ids: set[str] = set()
         super().__init__(bus)
         self.bus.on(CrawlSetupEvent, self.on_CrawlSetupEvent)
-        if self.crawl_event_enabled:
-            self.bus.on(CrawlEvent, self.on_CrawlEvent)
         self.bus.on(CrawlAbortEvent, self.on_CrawlAbortEvent)
-        self.bus.on(CrawlStartEvent, self.on_CrawlStartEvent)
         self.bus.on(CrawlCleanupEvent, self.on_CrawlCleanupEvent)
 
     async def should_abort(self) -> bool:
@@ -256,124 +207,6 @@ class CrawlService(BaseService):
             if await self.should_abort():
                 return
 
-    async def on_CrawlEvent(self, event: CrawlEvent) -> None:
-        """Drive the full crawl lifecycle by emitting phase events in sequence.
-
-        CrawlSetupEvent → CrawlStartEvent → CrawlCleanupEvent → CrawlCompletedEvent
-        """
-        if event.output_dir != str(self.output_dir):
-            return
-        if event.event_id in self._active_crawl_event_ids or event.event_id in self._completed_crawl_event_ids:
-            return
-        self._active_crawl_event_ids.add(event.event_id)
-        try:
-            await self._run_root_crawl_event(event)
-        finally:
-            self._active_crawl_event_ids.discard(event.event_id)
-            self._completed_crawl_event_ids.add(event.event_id)
-
-    async def _run_root_crawl_event(self, event: CrawlEvent) -> None:
-        url = self.url
-        snapshot_id = self.snapshot.id
-        output_dir = str(self.output_dir)
-        if self.crawl_setup_enabled:
-            await _run_event_now(
-                event.emit(
-                    CrawlSetupEvent(
-                        url=url,
-                        snapshot_id=snapshot_id,
-                        output_dir=output_dir,
-                        event_timeout=self.crawl_setup_phase_timeout,
-                        event_handler_slow_timeout=slow_warning_timeout(self.crawl_setup_phase_timeout),
-                    ),
-                ),
-                self.crawl_setup_phase_timeout,
-            )
-        if await self.should_abort():
-            if self.crawl_cleanup_enabled:
-                await _run_event_now(
-                    event.emit(
-                        CrawlCleanupEvent(
-                            url=url,
-                            snapshot_id=snapshot_id,
-                            output_dir=output_dir,
-                            event_timeout=self.crawl_cleanup_phase_timeout,
-                            event_handler_slow_timeout=slow_warning_timeout(self.crawl_cleanup_phase_timeout),
-                        ),
-                    ),
-                    self.crawl_cleanup_phase_timeout,
-                )
-                return
-            if self.crawl_completed_enabled:
-                await _run_event_now(
-                    event.emit(CrawlCompletedEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir)),
-                    CrawlCompletedEvent.model_fields["event_timeout"].default,
-                )
-            return
-        if self.crawl_start_enabled:
-            await _run_event_now(
-                event.emit(
-                    CrawlStartEvent(
-                        url=url,
-                        snapshot_id=snapshot_id,
-                        output_dir=output_dir,
-                        event_timeout=self.snapshot_phase_timeout,
-                        event_handler_slow_timeout=slow_warning_timeout(self.snapshot_phase_timeout),
-                    ),
-                ),
-                self.snapshot_phase_timeout,
-            )
-        if self.crawl_cleanup_enabled:
-            await _run_event_now(
-                event.emit(
-                    CrawlCleanupEvent(
-                        url=url,
-                        snapshot_id=snapshot_id,
-                        output_dir=output_dir,
-                        event_timeout=self.crawl_cleanup_phase_timeout,
-                        event_handler_slow_timeout=slow_warning_timeout(self.crawl_cleanup_phase_timeout),
-                    ),
-                ),
-                self.crawl_cleanup_phase_timeout,
-            )
-            return
-        if self.crawl_completed_enabled:
-            await _run_event_now(
-                event.emit(CrawlCompletedEvent(url=url, snapshot_id=snapshot_id, output_dir=output_dir)),
-                CrawlCompletedEvent.model_fields["event_timeout"].default,
-            )
-
-    async def on_CrawlStartEvent(self, event: CrawlStartEvent) -> None:
-        """Start the snapshot phase after crawl setup completes.
-
-        Skipped when snapshot execution is disabled for this run.
-        """
-        if event.output_dir != str(self.output_dir):
-            return
-        if not self.crawl_start_enabled:
-            return
-        if await self.should_abort():
-            return
-        snapshot_event = event.emit(
-            SnapshotEvent(
-                url=self.url,
-                snapshot_id=self.snapshot.id,
-                output_dir=str(self.output_dir),
-                depth=0,
-                event_timeout=event.event_timeout,
-                event_handler_slow_timeout=slow_warning_timeout(event.event_timeout),
-            ),
-        )
-        await _run_event_now(snapshot_event, event.event_timeout)
-        completed_snapshot = await self.bus.find(
-            SnapshotCompletedEvent,
-            child_of=snapshot_event,
-            past=True,
-            future=event.event_timeout,
-        )
-        if completed_snapshot is None:
-            raise RuntimeError(f"Snapshot {self.snapshot.id} did not complete")
-
     async def on_CrawlCleanupEvent(self, event: CrawlCleanupEvent) -> None:
         """SIGTERM any crawl setup hooks that should still be running."""
         if event.output_dir != str(self.output_dir):
@@ -475,17 +308,6 @@ class CrawlService(BaseService):
                     )
                     for process_event, _ in started_processes
                 ],
-            )
-        if self.crawl_completed_enabled:
-            await _run_event_now(
-                event.emit(
-                    CrawlCompletedEvent(
-                        url=event.url,
-                        snapshot_id=event.snapshot_id,
-                        output_dir=event.output_dir,
-                    ),
-                ),
-                CrawlCompletedEvent.model_fields["event_timeout"].default,
             )
 
     async def on_CrawlAbortEvent(self, event: CrawlAbortEvent) -> None:

--- a/abx_dl/services/snapshot_service.py
+++ b/abx_dl/services/snapshot_service.py
@@ -15,7 +15,6 @@ from pydantic import ValidationError
 from ..config import RuntimeConfig, get_plugin_env
 from ..events import (
     CrawlAbortEvent,
-    CrawlStartEvent,
     ProcessEvent,
     ProcessCompletedEvent,
     ProcessKillEvent,
@@ -23,6 +22,7 @@ from ..events import (
     ProcessStdoutEvent,
     SnapshotCleanupEvent,
     SnapshotCompletedEvent,
+    SnapshotDiscoveredEvent,
     SnapshotEvent,
     slow_warning_timeout,
 )
@@ -51,7 +51,7 @@ async def _run_event_now(event: BaseEvent, timeout: float | None = None) -> Base
 class SnapshotService(BaseService):
     """Orchestrates the snapshot phase: extraction hooks, cleanup, completion.
 
-    The SnapshotEvent is emitted by CrawlService.on_CrawlStartEvent after the
+    The SnapshotEvent is emitted by CrawlLifecycleService after the
     install and crawl-setup phases have already completed::
 
         InstallEvent
@@ -61,12 +61,12 @@ class SnapshotService(BaseService):
         │   └── SnapshotEvent (depth=0)                    # triggers this service
         │       │
         │       │  ── Snapshot hook handlers run serially ──
-        │       │  (only root SnapshotEvents emitted by CrawlStartEvent)
+        │       │  (the event matching this service's snapshot context)
         │       │
         │       ├── on_Snapshot__35_wget.finite.bg
         │       │   └── ProcessEvent
         │       │       ├── ProcessStdoutEvent
-        │       │       │   ├── SnapshotEvent (discovered URL)
+        │       │       │   ├── SnapshotDiscoveredEvent
         │       │       │   └── ArchiveResultEvent (inline)
         │       │       └── ProcessCompletedEvent
         │       │           └── ArchiveResultEvent (enriched)
@@ -83,9 +83,9 @@ class SnapshotService(BaseService):
         ├── CrawlCleanupEvent
         └── CrawlCompletedEvent
 
-    Only the root SnapshotEvent emitted directly by CrawlStartEvent executes
-    snapshot hooks. SnapshotEvents emitted from hook stdout are discovery
-    records for higher-level consumers such as ArchiveBox.
+    Each service instance handles only the exact SnapshotEvent matching its
+    injected snapshot and output directory. Hook-emitted discovery records are
+    routed to SnapshotDiscoveredEvent facts, never back into executable work.
 
     RuntimeConfig is injected for this snapshot so shared-bus MachineEvent
     history from another snapshot cannot change its hook environment or limits.
@@ -104,7 +104,7 @@ class SnapshotService(BaseService):
     EMITS: ClassVar[list[type[BaseEvent]]] = [
         ProcessEvent,
         ProcessKillEvent,
-        SnapshotEvent,
+        SnapshotDiscoveredEvent,
         SnapshotCleanupEvent,
         SnapshotCompletedEvent,
     ]
@@ -119,11 +119,9 @@ class SnapshotService(BaseService):
         catalog: PluginCatalog,
         config: RuntimeConfig,
         snapshot_phase_timeout: float = 300.0,
-        snapshot_cleanup_enabled: bool = True,
         snapshot_cleanup_phase_timeout: float = 300.0,
         abort_requested: Callable[[], bool | Awaitable[bool]] | None = None,
         selected_hooks_by_plugin: dict[str, set[str] | None] | None = None,
-        emit_discovered_snapshot_events: bool = True,
     ):
         self.url = url
         self.snapshot = snapshot
@@ -144,11 +142,9 @@ class SnapshotService(BaseService):
                 self.hooks.append((plugin, hook))
         self.hooks.sort(key=lambda item: item[1].sort_key)
         self.snapshot_phase_timeout = snapshot_phase_timeout
-        self.snapshot_cleanup_enabled = snapshot_cleanup_enabled
         self.snapshot_cleanup_phase_timeout = snapshot_cleanup_phase_timeout
         self.abort_requested = False
         self.abort_requested_callback = abort_requested
-        self.emit_discovered_snapshot_events = emit_discovered_snapshot_events
         self.limit_state: CrawlLimitState | None = None
         self.config: RuntimeConfig = config
         self._hook_timeouts: dict[tuple[str, str], int] = {}
@@ -209,14 +205,6 @@ class SnapshotService(BaseService):
 
         async def on_SnapshotEvent__hook(event: SnapshotEvent) -> None:
             if event.output_dir != str(self.output_dir) or event.snapshot_id != self.snapshot.id:
-                return
-            parent_event = await self.bus.find(
-                CrawlStartEvent,
-                past=True,
-                future=False,
-                where=lambda candidate: self.bus.event_is_parent_of(candidate, event),
-            )
-            if not isinstance(parent_event, CrawlStartEvent):
                 return
             if await self.should_abort():
                 return
@@ -325,29 +313,16 @@ class SnapshotService(BaseService):
             return
         if self.limit_state is None:
             self.limit_state = CrawlLimitState.from_config(self.config.user.model_dump(mode="json"))
-        parent_event = await self.bus.find(
-            CrawlStartEvent,
-            past=True,
-            future=False,
-            where=lambda candidate: self.bus.event_is_parent_of(candidate, event),
-        )
-        if not isinstance(parent_event, CrawlStartEvent):
-            return
         if self.limit_state.has_limits():
             self.limit_state.admit_snapshot(event.snapshot_id)
 
     async def on_ProcessStdoutEvent(self, event: ProcessStdoutEvent) -> None:
-        """Route type=Snapshot records to SnapshotEvent.
+        """Route type=Snapshot records to SnapshotDiscoveredEvent facts.
 
         Discovered snapshots inherit their parent SnapshotEvent's depth and
         increment it by one.
         """
         if Path(event.output_dir).parent != self.output_dir:
-            return
-        # This flag controls only whether protocol records become new work.
-        # ProcessStdoutEvent remains the shared audit/result stream for other
-        # services even when an embedder persists discoveries itself.
-        if not self.emit_discovered_snapshot_events:
             return
         try:
             record = json.loads(event.line)
@@ -357,8 +332,11 @@ class SnapshotService(BaseService):
             return
         if "type" not in record or record["type"] != "Snapshot":
             return
+        snapshot_payload = {key: value for key, value in record.items() if key != "type"}
+        if not snapshot_payload.get("id"):
+            snapshot_payload.pop("id", None)
         try:
-            discovered_snapshot = Snapshot(**record)
+            discovered_snapshot = Snapshot(**snapshot_payload)
         except ValidationError:
             return
         if self.limit_state is None:
@@ -374,33 +352,22 @@ class SnapshotService(BaseService):
         if parent_snapshot is None:
             return
         assert isinstance(parent_snapshot, SnapshotEvent)
+        discovered_snapshot = discovered_snapshot.model_copy(update={"depth": parent_snapshot.depth + 1})
         event.emit(
-            SnapshotEvent(
-                url=discovered_snapshot.url,
-                snapshot_id=discovered_snapshot.id,
-                output_dir=str(self.output_dir),
-                depth=parent_snapshot.depth + 1,
-                event_timeout=event.event_timeout,
-                event_handler_slow_timeout=slow_warning_timeout(event.event_timeout),
+            SnapshotDiscoveredEvent(
+                snapshot=discovered_snapshot,
+                plugin_name=event.plugin_name,
+                hook_name=event.hook_name,
             ),
         )
 
     async def on_SnapshotEvent(self, event: SnapshotEvent) -> None:
         """Run snapshot hooks in sort order, then emit cleanup and completion.
 
-        Only the root SnapshotEvent emitted directly by CrawlStartEvent drives
-        hook execution and cleanup. Discovered SnapshotEvents emitted from hook
-        stdout are left for higher-level consumers like ArchiveBox.
+        The exact snapshot/output pair identifies this service's executable
+        command. Discovery uses a separate event type and cannot re-enter it.
         """
         if event.output_dir != str(self.output_dir) or event.snapshot_id != self.snapshot.id:
-            return
-        parent_event = await self.bus.find(
-            CrawlStartEvent,
-            past=True,
-            future=False,
-            where=lambda candidate: self.bus.event_is_parent_of(candidate, event),
-        )
-        if not isinstance(parent_event, CrawlStartEvent):
             return
         if event.event_id in self._active_snapshot_event_ids or event.event_id in self._completed_snapshot_event_ids:
             return
@@ -440,27 +407,14 @@ class SnapshotService(BaseService):
                 if self.limit_state.get_snapshot_stop_reason(event.snapshot_id) == "snapshot_max_size":
                     break
         finally:
-            if self.snapshot_cleanup_enabled:
-                cleanup_event = SnapshotCleanupEvent(
-                    url=url,
-                    snapshot_id=snapshot_id,
-                    output_dir=output_dir,
-                    event_timeout=self.snapshot_cleanup_phase_timeout,
-                    event_handler_slow_timeout=slow_warning_timeout(self.snapshot_cleanup_phase_timeout),
-                )
-                await _run_event_now(event.emit(cleanup_event), self.snapshot_cleanup_phase_timeout)
-        if self.snapshot_cleanup_enabled:
-            return
-
-        completed_event = SnapshotCompletedEvent(
-            url=url,
-            snapshot_id=snapshot_id,
-            output_dir=output_dir,
-            event_timeout=self.snapshot_phase_timeout,
-            event_handler_timeout=self.snapshot_phase_timeout,
-            event_handler_slow_timeout=slow_warning_timeout(self.snapshot_phase_timeout),
-        )
-        event.emit(completed_event)
+            cleanup_event = SnapshotCleanupEvent(
+                url=url,
+                snapshot_id=snapshot_id,
+                output_dir=output_dir,
+                event_timeout=self.snapshot_cleanup_phase_timeout,
+                event_handler_slow_timeout=slow_warning_timeout(self.snapshot_cleanup_phase_timeout),
+            )
+            await _run_event_now(event.emit(cleanup_event), self.snapshot_cleanup_phase_timeout)
 
     async def on_SnapshotCleanupEvent(self, event: SnapshotCleanupEvent) -> None:
         """SIGTERM all background snapshot hooks so they can flush and exit.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ from abx_dl.config import GlobalConfig, RuntimeConfig, get_config, get_explicit_
 from abx_dl.events import MachineEvent
 from abx_dl.catalog import PluginCatalog
 from abx_dl.models import PluginEnv
-from abx_dl.orchestrator import ExecutionPlan, create_bus, install_plugins
+from abx_dl.orchestrator import create_bus, install_plugins
 from abx_dl.services.binary_service import build_plugin_process_env
 from platformdirs import user_config_path
 
@@ -149,13 +149,10 @@ def test_plugin_env_exports_abxpkg_runtime_after_real_install_phase(tmp_path: Pa
     bus = create_bus(total_timeout=300.0, name=f"test_config_shared_runtime_{tmp_path.name}")
 
     async def run() -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
-        plan = ExecutionPlan.build(
-            plugins,
-            selected_plugins=["ytdlp"],
-            config=get_explicit_user_env(),
-        )
+        selected = plugins.select(["ytdlp"])
         await install_plugins(
-            plan,
+            selected,
+            config=get_explicit_user_env(),
             output_dir=run_output_dir,
             bus=bus,
         )

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -24,13 +24,14 @@ from abx_dl.events import (
     ProcessStdoutEvent,
     SnapshotCleanupEvent,
     SnapshotCompletedEvent,
+    SnapshotDiscoveredEvent,
     SnapshotEvent,
 )
 from abx_dl.execution import build_hook_args, execute_hook, iter_plugin_command
 from abx_dl.limits import CrawlLimitState
 from abx_dl.catalog import PluginCatalog, PluginConfigResolver
 from abx_dl.models import Hook, PluginCommand, Snapshot
-from abx_dl.orchestrator import ExecutionPlan, create_bus, download as execute_download
+from abx_dl.orchestrator import create_bus, download as execute_download, install_plugins, parse_input
 from abx_dl.services.archive_result_service import ArchiveResultService
 from abx_dl.services.binary_service import PluginBinaryEnvService
 from abx_dl.services.crawl_service import CrawlService
@@ -146,27 +147,7 @@ def _binary_extra_context(
     }
 
 
-def _execution_plan(
-    plugins,
-    *,
-    selected_plugins=None,
-    config_overrides=None,
-    derived_config_overrides=None,
-    dry_run=False,
-):
-    catalog = plugins if isinstance(plugins, PluginCatalog) else PluginCatalog(dict(plugins))
-    config = {**get_explicit_user_env(), **dict(config_overrides or {})}
-    if dry_run:
-        config["DRY_RUN"] = True
-    return ExecutionPlan.build(
-        catalog,
-        selected_plugins=selected_plugins if selected_plugins is not None else list(catalog),
-        config=config,
-        derived_config=derived_config_overrides,
-    )
-
-
-async def _download_with_plan(
+async def _download(
     url,
     catalog,
     output_dir,
@@ -177,14 +158,19 @@ async def _download_with_plan(
     dry_run=False,
     **kwargs,
 ):
-    plan = _execution_plan(
-        catalog,
-        selected_plugins=selected_plugins,
-        config_overrides=config_overrides,
-        derived_config_overrides=derived_config_overrides,
-        dry_run=dry_run,
+    catalog = catalog if isinstance(catalog, PluginCatalog) else PluginCatalog(dict(catalog))
+    selected = catalog.select(selected_plugins if selected_plugins is not None else list(catalog))
+    config = {**get_explicit_user_env(), **dict(config_overrides or {})}
+    if dry_run:
+        config["DRY_RUN"] = True
+    return await execute_download(
+        url,
+        selected,
+        output_dir,
+        config=config,
+        derived_config=derived_config_overrides,
+        **kwargs,
     )
-    return await execute_download(url, plan, output_dir, **kwargs)
 
 
 def _run_download(*args, **kwargs):
@@ -210,7 +196,7 @@ def _run_download(*args, **kwargs):
 
     async def run() -> None:
         try:
-            await _download_with_plan(
+            await _download(
                 url,
                 plugins,
                 output_dir,
@@ -225,6 +211,43 @@ def _run_download(*args, **kwargs):
 
     asyncio.run(run())
     return results
+
+
+async def _run_crawl_setup_hooks(
+    *,
+    bus,
+    catalog: PluginCatalog,
+    url: str,
+    output_dir: Path,
+    config_overrides=None,
+) -> tuple[CrawlEvent, Snapshot]:
+    """Attach only the plugin crawl-hook suite and emit its setup phase."""
+    config = {**get_explicit_user_env(), **dict(config_overrides or {}), "ABX_RUNTIME": "abx-dl"}
+    install_bus = create_bus(total_timeout=300.0, name=f"test_crawl_setup_install_{uuid4().hex[:8]}")
+    try:
+        await install_plugins(catalog, config=config, output_dir=output_dir, emit_jsonl=False, bus=install_bus)
+    finally:
+        await install_bus.destroy(clear=False)
+    snapshot = Snapshot(url=url)
+    PluginBinaryEnvService(bus, catalog=catalog)
+    BinaryService(bus, auto_install=True)
+    ProcessService(bus, emit_jsonl=False, interactive_tty=False)
+    CrawlService(bus, url=url, snapshot=snapshot, output_dir=output_dir, catalog=catalog)
+    await bus.emit(MachineEvent(config=config, config_type="user")).now()
+    crawl_event = CrawlEvent(url=url, snapshot_id=snapshot.id, output_dir=str(output_dir))
+    await bus.emit(crawl_event).now()
+    setup_event = bus.emit(
+        CrawlSetupEvent(
+            url=url,
+            snapshot_id=snapshot.id,
+            output_dir=str(output_dir),
+            event_parent_id=crawl_event.event_id,
+        ),
+    )
+    await setup_event.now()
+    await setup_event.wait()
+    await setup_event.event_results_list()
+    return crawl_event, snapshot
 
 
 def test_process_command_executes_hooks_through_declared_shebang(tmp_path: Path) -> None:
@@ -297,7 +320,9 @@ def _resolve_real_wget_binary(tmp_path: Path) -> BinaryEvent:
     plugins = PluginCatalog.discover()
     selected = plugins.select(["wget"])
     bus = create_bus(total_timeout=30.0, name=f"resolve_real_wget_binary_{tmp_path.name}")
-    ExecutionPlan.build(selected, selected_plugins=selected).attach_services(bus, auto_install=True, emit_jsonl=False)
+    PluginBinaryEnvService(bus, catalog=selected)
+    BinaryService(bus, auto_install=True)
+    ProcessService(bus, emit_jsonl=False, interactive_tty=False)
     installed_events: list[BinaryEvent] = []
 
     async def on_BinaryEvent(event: BinaryEvent) -> None:
@@ -353,7 +378,9 @@ def test_binary_installed_event_preserves_child_provider_metadata(tmp_path: Path
     plugins = PluginCatalog.discover()
     selected = plugins.select(["wget"])
     bus = create_bus(total_timeout=30.0, name=f"binary_installed_metadata_{tmp_path.name}")
-    ExecutionPlan.build(selected, selected_plugins=selected).attach_services(bus, auto_install=True, emit_jsonl=False)
+    PluginBinaryEnvService(bus, catalog=selected)
+    BinaryService(bus, auto_install=True)
+    ProcessService(bus, emit_jsonl=False, interactive_tty=False)
     installed_events: list[BinaryEvent] = []
 
     async def on_BinaryEvent(event: BinaryEvent) -> None:
@@ -531,7 +558,9 @@ def test_binary_event_validates_derived_config_binary_through_abxpkg_resolution(
     plugins = PluginCatalog.discover()
     selected = plugins.select(["wget"])
     bus = create_bus(total_timeout=60.0, name=f"cached_binary_before_provider_{tmp_path.name}")
-    ExecutionPlan.build(selected, selected_plugins=selected).attach_services(bus, auto_install=True, emit_jsonl=False)
+    PluginBinaryEnvService(bus, catalog=selected)
+    BinaryService(bus, auto_install=True)
+    ProcessService(bus, emit_jsonl=False, interactive_tty=False)
     installed_events: list[BinaryEvent] = []
     process_events: list[ProcessEvent] = []
 
@@ -603,40 +632,11 @@ def test_required_binary_requests_preserve_extra_config_fields() -> None:
     assert "{'User-Agent': 'abxpkg sonic bootstrap/1.7.4'}" in install_script
 
 
-def test_execution_plan_centralizes_selection_timeouts_and_runtime_config(tmp_path: Path) -> None:
-    plan = ExecutionPlan.build(
-        PluginCatalog.discover(runtime="archivebox"),
-        selected_plugins=["title", "wget"],
-        config={"TIMEOUT": 17},
-        derived_config={"WGET_BINARY": str(tmp_path / "wget")},
-        runtime="archivebox",
-    )
-
-    assert {"chrome", "title", "wget"} <= set(plan.catalog)
-    assert plan.runtime_config.user.ABX_RUNTIME == "archivebox"
-    assert plan.runtime_config.user.TIMEOUT == 17
-    assert plan.runtime_config.derived == {"WGET_BINARY": str(tmp_path / "wget")}
-    assert plan.snapshot_timeout >= 60.0
-
-    async def run() -> list[MachineEvent]:
-        bus = create_bus(total_timeout=5.0, name=f"execution_plan_{uuid4().hex[:8]}")
-        observed: list[MachineEvent] = []
-
-        async def on_MachineEvent(event: MachineEvent) -> None:
-            observed.append(event)
-
-        bus.on(MachineEvent, on_MachineEvent)
-        await plan.seed_config(bus)
-        await bus.wait_until_idle()
-        return observed
-
-    events = asyncio.run(run())
-    assert [event.config_type for event in events] == ["user", "derived"]
-
-
 def test_binary_service_stops_after_successful_provider_result(tmp_path: Path) -> None:
     bus = create_bus(total_timeout=30.0, name=f"binary_provider_result_{tmp_path.name}")
-    ExecutionPlan.build(PluginCatalog({})).attach_services(bus, auto_install=True, emit_jsonl=False)
+    PluginBinaryEnvService(bus, catalog=PluginCatalog({}))
+    BinaryService(bus, auto_install=True)
+    ProcessService(bus, emit_jsonl=False, interactive_tty=False)
     process_events: list[ProcessEvent] = []
     binary_events: list[BinaryEvent] = []
 
@@ -774,7 +774,9 @@ def test_binary_event_delegates_stale_cached_config_binary_to_abxpkg_resolution(
     plugins = PluginCatalog.discover()
     selected = plugins.select(["wget"])
     bus = create_bus(total_timeout=60.0, name=f"stale_cached_binary_{tmp_path.name}")
-    ExecutionPlan.build(selected, selected_plugins=selected).attach_services(bus, auto_install=True, emit_jsonl=False)
+    PluginBinaryEnvService(bus, catalog=selected)
+    BinaryService(bus, auto_install=True)
+    ProcessService(bus, emit_jsonl=False, interactive_tty=False)
     installed_events: list[BinaryEvent] = []
     process_events: list[ProcessEvent] = []
 
@@ -827,7 +829,9 @@ def test_binary_event_delegates_missing_user_binary_abspath_override_to_abxpkg(t
     plugins = PluginCatalog.discover()
     selected = plugins.select(["wget"])
     bus = create_bus(total_timeout=60.0, name=f"user_abspath_override_{tmp_path.name}")
-    ExecutionPlan.build(selected, selected_plugins=selected).attach_services(bus, auto_install=True, emit_jsonl=False)
+    PluginBinaryEnvService(bus, catalog=selected)
+    BinaryService(bus, auto_install=True)
+    ProcessService(bus, emit_jsonl=False, interactive_tty=False)
     installed_events: list[BinaryEvent] = []
     process_events: list[ProcessEvent] = []
 
@@ -938,7 +942,7 @@ def test_real_js_snapshot_hook_replays_early_sigterm_to_late_cleanup_handler(tmp
 
     async def run() -> ProcessCompletedEvent | None:
         download_task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 "https://example.com",
                 selected,
                 output_dir,
@@ -1400,11 +1404,6 @@ def test_crawl_setup_hook_binary_event_env_replay_applies_newest_last(tmp_path: 
         snapshot=snapshot,
         output_dir=output_dir,
         catalog=PluginCatalog({plugin.name: plugin}),
-        crawl_event_enabled=False,
-        crawl_start_enabled=False,
-        crawl_cleanup_enabled=False,
-        crawl_completed_enabled=False,
-        crawl_setup_phase_timeout=10.0,
     )
     wget_binary = _resolve_real_wget_binary(tmp_path)
 
@@ -1484,7 +1483,7 @@ def test_snapshot_hook_waits_for_selected_plugin_outputs(tmp_path: Path, httpser
 
     async def run() -> None:
         download_task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 stream_url,
                 catalog=PluginCatalog(selected),
                 output_dir=output_dir,
@@ -1545,7 +1544,7 @@ def test_snapshot_abort_stops_scheduling_later_hooks(tmp_path: Path, httpserver:
         int,
     ]:
         task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 stream_url,
                 catalog=PluginCatalog(selected),
                 output_dir=output_dir,
@@ -1689,25 +1688,17 @@ def test_crawl_setup_background_daemon_survives_until_explicit_cleanup(tmp_path:
     bus = create_bus(total_timeout=300.0, name=f"crawl_bg_lifetime_{tmp_path.name}")
 
     async def run() -> ProcessCompletedEvent | None:
-        await _download_with_plan(
-            "https://example.com",
-            catalog=PluginCatalog({plugin.name: plugin}),
-            output_dir=output_dir,
-            selected_plugins=[plugin.name],
-            auto_install=True,
-            emit_jsonl=False,
-            interactive_tty=False,
-            crawl_start_enabled=False,
-            crawl_cleanup_enabled=False,
+        crawl_event, _snapshot = await _run_crawl_setup_hooks(
             bus=bus,
+            catalog=PluginCatalog({plugin.name: plugin}),
+            url="https://example.com",
+            output_dir=output_dir,
         )
         started = await bus.find(ProcessStartedEvent, past=True, future=False, hook_name=daemon_hook_name)
         assert isinstance(started, ProcessStartedEvent)
         os.kill(started.pid, 0)
         assert started.stdout_file.is_file()
         started.stdout_file.unlink()
-        crawl_event = await bus.find(CrawlEvent, past=True, future=False)
-        assert isinstance(crawl_event, CrawlEvent)
         await bus.emit(
             CrawlCleanupEvent(
                 url=crawl_event.url,
@@ -1767,19 +1758,29 @@ def test_crawl_completed_waits_for_cleanup_process_listeners(tmp_path: Path) -> 
     bus.on(CrawlCompletedEvent, on_CrawlCompletedEvent)
 
     async def run() -> None:
-        download_task = asyncio.create_task(
-            _download_with_plan(
-                "https://example.com",
-                catalog=PluginCatalog({plugin.name: plugin}),
-                output_dir=output_dir,
-                selected_plugins=[plugin.name],
-                auto_install=True,
-                emit_jsonl=False,
-                interactive_tty=False,
-                crawl_start_enabled=False,
+        async def run_setup_and_cleanup() -> None:
+            crawl_event, snapshot = await _run_crawl_setup_hooks(
                 bus=bus,
-            ),
-        )
+                catalog=PluginCatalog({plugin.name: plugin}),
+                url="https://example.com",
+                output_dir=output_dir,
+            )
+            cleanup_event = bus.emit(
+                CrawlCleanupEvent(
+                    url=crawl_event.url,
+                    snapshot_id=snapshot.id,
+                    output_dir=str(output_dir),
+                    event_parent_id=crawl_event.event_id,
+                ),
+            )
+            await cleanup_event.now()
+            await cleanup_event.wait()
+            await cleanup_event.event_results_list()
+            await bus.emit(
+                CrawlCompletedEvent(url=crawl_event.url, snapshot_id=snapshot.id, output_dir=str(output_dir)),
+            ).now()
+
+        download_task = asyncio.create_task(run_setup_and_cleanup())
         await asyncio.wait_for(listener_started.wait(), timeout=240.0)
         assert await bus.find(CrawlCompletedEvent, past=True, future=False) is None
         release_listener.set()
@@ -1800,7 +1801,7 @@ def test_crawl_abort_during_setup_cleans_background_daemon(tmp_path: Path) -> No
 
     async def run() -> ProcessCompletedEvent | None:
         task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 "https://example.com",
                 catalog=PluginCatalog({plugin.name: plugin}),
                 output_dir=output_dir,
@@ -1808,7 +1809,6 @@ def test_crawl_abort_during_setup_cleans_background_daemon(tmp_path: Path) -> No
                 auto_install=True,
                 emit_jsonl=False,
                 interactive_tty=False,
-                crawl_start_enabled=False,
                 bus=bus,
             ),
         )
@@ -1846,7 +1846,7 @@ def test_crawl_abort_during_foreground_setup_interrupts_hook_and_stops_later_set
 
     async def run() -> tuple[ProcessCompletedEvent | None, ProcessCompletedEvent | None, list[ProcessStartedEvent]]:
         crawl_task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 "https://example.com",
                 catalog=PluginCatalog(selected),
                 output_dir=output_dir,
@@ -1855,7 +1855,6 @@ def test_crawl_abort_during_foreground_setup_interrupts_hook_and_stops_later_set
                 auto_install=True,
                 emit_jsonl=False,
                 interactive_tty=False,
-                crawl_start_enabled=False,
                 bus=bus,
             ),
         )
@@ -1912,7 +1911,7 @@ def test_crawl_abort_cleans_real_chrome_process_tree_and_foreground_hook(
 
     async def run() -> tuple[int, int, int, list[ProcessCompletedEvent], list[ProcessKillEvent]]:
         download_task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 stream_url,
                 catalog=PluginCatalog({plugin.name: plugin}),
                 output_dir=output_dir,
@@ -1988,17 +1987,12 @@ def test_real_chrome_hook_completes_while_child_survives_then_lifecycle_cleans_i
 
     async def run() -> tuple[ProcessCompletedEvent, int, ProcessCompletedEvent]:
         keepalive_bus = create_bus(total_timeout=300.0, name=f"chrome_keepalive_parent_{tmp_path.name}")
-        await _download_with_plan(
-            "https://example.com",
-            catalog=PluginCatalog({plugin.name: plugin}),
-            output_dir=output_dir,
-            selected_plugins=[plugin.name],
-            config_overrides={"CHROME_KEEPALIVE": True},
-            auto_install=True,
-            emit_jsonl=False,
-            interactive_tty=False,
-            crawl_start_enabled=False,
+        await _run_crawl_setup_hooks(
             bus=keepalive_bus,
+            catalog=PluginCatalog({plugin.name: plugin}),
+            url="https://example.com",
+            output_dir=output_dir,
+            config_overrides={"CHROME_KEEPALIVE": True},
         )
         await keepalive_bus.wait_until_idle()
         first_completed = await keepalive_bus.find(
@@ -2012,18 +2006,24 @@ def test_real_chrome_hook_completes_while_child_survives_then_lifecycle_cleans_i
         assert _pid_is_alive(chrome_pid)
 
         cleanup_bus = create_bus(total_timeout=300.0, name=f"chrome_adopt_cleanup_{tmp_path.name}")
-        await _download_with_plan(
-            "https://example.com",
-            catalog=PluginCatalog({plugin.name: plugin}),
-            output_dir=output_dir,
-            selected_plugins=[plugin.name],
-            config_overrides={"CHROME_KEEPALIVE": False},
-            auto_install=True,
-            emit_jsonl=False,
-            interactive_tty=False,
-            crawl_start_enabled=False,
+        crawl_event, snapshot = await _run_crawl_setup_hooks(
             bus=cleanup_bus,
+            catalog=PluginCatalog({plugin.name: plugin}),
+            url="https://example.com",
+            output_dir=output_dir,
+            config_overrides={"CHROME_KEEPALIVE": False},
         )
+        cleanup_event = cleanup_bus.emit(
+            CrawlCleanupEvent(
+                url=crawl_event.url,
+                snapshot_id=snapshot.id,
+                output_dir=str(output_dir),
+                event_parent_id=crawl_event.event_id,
+            ),
+        )
+        await cleanup_event.now()
+        await cleanup_event.wait()
+        await cleanup_event.event_results_list()
         await cleanup_bus.wait_until_idle()
         second_completed = await cleanup_bus.find(
             ProcessCompletedEvent,
@@ -2038,7 +2038,7 @@ def test_real_chrome_hook_completes_while_child_survives_then_lifecycle_cleans_i
 
     assert first_completed.status == "succeeded"
     assert first_completed.exit_code == 0
-    assert second_completed.status == "succeeded"
+    assert second_completed.status == "succeeded", second_completed.stderr
     assert second_completed.exit_code == 0
     assert not _pid_is_alive(chrome_pid)
     assert not (output_dir / "chrome" / "chrome.pid").exists()
@@ -2054,7 +2054,7 @@ def test_crawl_abort_from_crawl_event_interrupts_active_setup_hook(tmp_path: Pat
 
     async def run() -> tuple[ProcessCompletedEvent | None, list[ProcessStartedEvent]]:
         task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 "https://example.com",
                 catalog=PluginCatalog(selected),
                 output_dir=output_dir,
@@ -2062,7 +2062,6 @@ def test_crawl_abort_from_crawl_event_interrupts_active_setup_hook(tmp_path: Pat
                 auto_install=True,
                 emit_jsonl=False,
                 interactive_tty=False,
-                crawl_start_enabled=False,
                 bus=bus,
             ),
         )
@@ -2128,7 +2127,7 @@ def test_process_kill_uses_live_subprocess_handle_when_pid_file_validation_fails
 
     async def run() -> ProcessCompletedEvent:
         download_task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 stream_url,
                 catalog=PluginCatalog({plugin.name: plugin}),
                 output_dir=output_dir,
@@ -2216,7 +2215,7 @@ def test_background_process_event_returns_after_real_hook_start(tmp_path: Path, 
 
     async def run() -> ProcessCompletedEvent:
         download_task = asyncio.create_task(
-            _download_with_plan(
+            _download(
                 stream_url,
                 catalog=PluginCatalog({plugin.name: plugin}),
                 output_dir=output_dir,
@@ -2453,19 +2452,71 @@ def test_download_can_suppress_jsonl_stdout(tmp_path: Path, capsys) -> None:
     assert captured.out == ""
 
 
-def test_nested_snapshot_events_are_emitted_but_ignored_by_snapshot_hooks(tmp_path: Path) -> None:
+def test_parse_input_runs_only_opted_in_real_hooks_and_writes_durable_source(tmp_path: Path) -> None:
+    selected = PluginCatalog.discover().select(["title", "parse_txt_urls"])
+    output_dir = tmp_path / "input"
+
+    snapshots = asyncio.run(
+        parse_input(
+            "First https://example.com/one then https://example.net/two\n",
+            selected,
+            output_dir,
+            auto_install=False,
+        ),
+    )
+
+    assert (output_dir / "staticfile" / "stdin.txt").read_text() == ("First https://example.com/one then https://example.net/two\n")
+    assert {snapshot.url for snapshot in snapshots} == {
+        "https://example.com/one",
+        "https://example.net/two",
+    }
+    assert {snapshot.depth for snapshot in snapshots} == {0}
+    assert {snapshot.plugin for snapshot in snapshots} == {"parse_txt_urls"}
+    manifest = (output_dir / "index.jsonl").read_text()
+    assert '"plugin": "parse_txt_urls"' in manifest
+    assert '"plugin": "title"' not in manifest
+
+
+def test_parse_input_preserves_jsonl_parser_metadata_at_depth_zero(tmp_path: Path) -> None:
+    selected = PluginCatalog.discover().select(["parse_jsonl_urls"])
+    source = json.dumps(
+        {
+            "url": "https://example.com/article",
+            "title": "An imported article",
+            "tags": ["reading", "archive"],
+            "bookmarked_at": "2025-01-02T03:04:05+00:00",
+        },
+    )
+
+    snapshots = asyncio.run(parse_input(source, selected, tmp_path / "jsonl", auto_install=False))
+
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.url == "https://example.com/article"
+    assert snapshot.depth == 0
+    assert snapshot.title == "An imported article"
+    assert snapshot.tags == "reading,archive"
+    assert snapshot.bookmarked_at == "2025-01-02T03:04:05+00:00"
+    assert snapshot.plugin == "parse_jsonl_urls"
+
+
+def test_nested_snapshot_records_emit_discovery_facts_not_snapshot_commands(tmp_path: Path) -> None:
     bus = create_bus(total_timeout=60.0, name=f"nested_snapshot_events_{tmp_path.name}")
     seen_snapshot_events: list[tuple[int, str]] = []
+    seen_discoveries: list[tuple[int, str]] = []
     child_listener_started = asyncio.Event()
     release_child_listener = asyncio.Event()
 
     async def on_SnapshotEvent(event: SnapshotEvent) -> None:
         seen_snapshot_events.append((event.depth, event.url))
-        if event.depth > 0:
-            child_listener_started.set()
-            await release_child_listener.wait()
+
+    async def on_SnapshotDiscoveredEvent(event: SnapshotDiscoveredEvent) -> None:
+        seen_discoveries.append((event.snapshot.depth, event.snapshot.url))
+        child_listener_started.set()
+        await release_child_listener.wait()
 
     bus.on(SnapshotEvent, on_SnapshotEvent)
+    bus.on(SnapshotDiscoveredEvent, on_SnapshotDiscoveredEvent)
     ProcessService(bus, emit_jsonl=False, interactive_tty=False)
     snapshot = Snapshot(url="https://example.com", depth=0, id="root-depth-0")
     SnapshotService(
@@ -2528,17 +2579,18 @@ def test_nested_snapshot_events_are_emitted_but_ignored_by_snapshot_hooks(tmp_pa
         assert completed_without_waiting
 
     asyncio.run(run())
-    assert seen_snapshot_events == [(0, "https://example.com"), (1, "https://example.com/child")]
+    assert seen_snapshot_events == [(0, "https://example.com")]
+    assert seen_discoveries == [(1, "https://example.com/child")]
 
 
 def test_discovered_snapshot_depth_increments_from_parent_snapshot(tmp_path: Path) -> None:
     bus = create_bus(total_timeout=60.0, name=f"discovered_snapshot_depth_{tmp_path.name}")
-    seen_snapshot_events: list[tuple[int, str]] = []
+    seen_discoveries: list[tuple[int, str]] = []
 
-    async def on_SnapshotEvent(event: SnapshotEvent) -> None:
-        seen_snapshot_events.append((event.depth, event.url))
+    async def on_SnapshotDiscoveredEvent(event: SnapshotDiscoveredEvent) -> None:
+        seen_discoveries.append((event.snapshot.depth, event.snapshot.url))
 
-    bus.on(SnapshotEvent, on_SnapshotEvent)
+    bus.on(SnapshotDiscoveredEvent, on_SnapshotDiscoveredEvent)
     ProcessService(bus, emit_jsonl=False, interactive_tty=False)
     snapshot = Snapshot(url="https://example.com/parent", depth=2, id="parent-depth-2")
     SnapshotService(
@@ -2592,7 +2644,7 @@ def test_discovered_snapshot_depth_increments_from_parent_snapshot(tmp_path: Pat
         await bus.wait_until_idle()
 
     asyncio.run(run())
-    assert seen_snapshot_events == [(2, "https://example.com/parent"), (3, "https://example.com/grandchild")]
+    assert seen_discoveries == [(3, "https://example.com/grandchild")]
 
 
 def test_inline_archive_result_collects_current_output_files(tmp_path: Path) -> None:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -7,6 +7,8 @@ import threading
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
+
 from abx_dl.config import GlobalConfig, RuntimeConfig, get_explicit_user_env, get_initial_env, get_required_binary_requests
 from abx_dl.events import (
     ArchiveResultEvent,
@@ -2473,8 +2475,46 @@ def test_parse_input_runs_only_opted_in_real_hooks_and_writes_durable_source(tmp
     assert {snapshot.depth for snapshot in snapshots} == {0}
     assert {snapshot.plugin for snapshot in snapshots} == {"parse_txt_urls"}
     manifest = (output_dir / "index.jsonl").read_text()
+    assert '"type": "Snapshot"' not in manifest
     assert '"plugin": "parse_txt_urls"' in manifest
     assert '"plugin": "title"' not in manifest
+
+
+def test_orchestration_rejects_reusing_a_bus(tmp_path: Path) -> None:
+    async def run() -> None:
+        bus = create_bus(total_timeout=60.0, name=f"single_run_bus_{tmp_path.name}")
+        await execute_download(
+            "https://example.com",
+            PluginCatalog({}),
+            tmp_path / "first",
+            auto_install=False,
+            emit_jsonl=False,
+            interactive_tty=False,
+            bus=bus,
+        )
+        with pytest.raises(RuntimeError, match="create a fresh EventBus"):
+            await execute_download(
+                "https://example.net",
+                PluginCatalog({}),
+                tmp_path / "second",
+                auto_install=False,
+                emit_jsonl=False,
+                interactive_tty=False,
+                bus=bus,
+            )
+
+    asyncio.run(run())
+
+
+def test_parse_input_rejects_reusing_a_bus(tmp_path: Path) -> None:
+    async def run() -> None:
+        bus = create_bus(total_timeout=60.0, name=f"single_parse_bus_{tmp_path.name}")
+        selected = PluginCatalog.discover().select(["parse_txt_urls"])
+        await parse_input("https://example.com/one\n", selected, tmp_path / "first", auto_install=False, bus=bus)
+        with pytest.raises(RuntimeError, match="create a fresh EventBus"):
+            await parse_input("https://example.net/two\n", selected, tmp_path / "second", auto_install=False, bus=bus)
+
+    asyncio.run(run())
 
 
 def test_parse_input_preserves_jsonl_parser_metadata_at_depth_zero(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- replace ExecutionPlan and injected service classes with direct orchestration and explicit bus listener composition
- separate standalone Crawl lifecycle sequencing from hook setup and cleanup
- add parse_input for durable raw-input parsing without synthetic ArchiveBox snapshots or pseudo URLs
- emit typed discovery facts while keeping Snapshot to ArchiveResult execution owned by abx-dl

## Verification

- full test suite: 167 passed
- all prek hooks passed, including ty and pyright
- real https://sweeting.me run completed in 80.74 seconds with 34 succeeded, 11 noresults, 0 failed, and no surviving processes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standalone downloads now sequence crawl phases through `CrawlLifecycleService` and let embedders attach only the listener suites they need, replacing the previous `ExecutionPlan` and phase-flag flow. Hook-emitted `Snapshot` records no longer recurse into snapshot execution; they become `SnapshotDiscoveredEvent` facts, while `parse_input()` returns depth-zero snapshots without creating a crawl, database row, or synthetic URL.

- `download()` and `install_plugins()` accept selected catalogs and config directly, with lifecycle hook selection and timeout calculation centralized in shared helpers.
- `parse_input()` writes `staticfile/stdin.txt` and runs only hooks that opt into `x-accepts-internal-input`.
- Discovery facts preserve parser metadata such as titles, tags, timestamps, and producing plugins.
- Each orchestration call reserves its event bus; reusing a bus raises `RuntimeError`.

<sup>Written for commit 32fe6bd80c2a25a04997b02fbae5dbc46084834e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ArchiveBox/abx-dl/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

